### PR TITLE
M1 #3: Create src/lib.rs with module declarations and stub modules

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,0 +1,5 @@
+//! Pool configuration enums and structs.
+//!
+//! This module contains the `AmmConfig` enum — the top-level declarative
+//! blueprint for creating any pool type — along with per-pool configuration
+//! structs that define the parameters for each AMM family.

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,0 +1,5 @@
+//! Fundamental domain value types used throughout the AMM library.
+//!
+//! This module contains the core value types that model the AMM domain:
+//! tokens, amounts, prices, ticks, positions, and swap specifications.
+//! All types use newtypes with validated constructors to enforce invariants.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,4 @@
+//! Unified error types for the Hydra AMM library.
+//!
+//! All fallible operations across the crate return `AmmError` as their
+//! error type, ensuring a consistent error handling experience for consumers.

--- a/src/factory/mod.rs
+++ b/src/factory/mod.rs
@@ -1,0 +1,5 @@
+//! Pool instantiation via the factory pattern.
+//!
+//! The `DefaultPoolFactory` creates pool instances from `AmmConfig`
+//! values, validating configuration and dispatching to the appropriate
+//! pool constructor based on the config variant.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,3 +37,13 @@
 //! [dependencies]
 //! hydra-amm = { version = "0.1", default-features = false, features = ["std", "constant-product"] }
 //! ```
+
+// Module declarations (always compiled)
+pub mod config;
+pub mod domain;
+pub mod error;
+pub mod factory;
+pub mod math;
+pub mod pools;
+pub mod prelude;
+pub mod traits;

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -1,0 +1,5 @@
+//! Arithmetic and precision utilities for AMM calculations.
+//!
+//! This module provides the `Precision` trait for feature-gated numeric
+//! backends, `CheckedArithmetic` for overflow-safe operations,
+//! `Rounding` for explicit division rounding, and tick math helpers.

--- a/src/pools/mod.rs
+++ b/src/pools/mod.rs
@@ -1,0 +1,5 @@
+//! Feature-gated pool implementations and the `PoolBox` dispatch enum.
+//!
+//! Each pool type is behind its own Cargo feature flag. The `PoolBox`
+//! enum provides zero-cost static dispatch across all enabled pool types,
+//! allowing heterogeneous collections without `dyn` trait objects.

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,37 @@
+//! Convenience re-exports for common types and traits.
+//!
+//! The prelude provides a single import to bring all commonly used items
+//! into scope:
+//!
+//! ```rust
+//! use hydra_amm::prelude::*;
+//! ```
+//!
+//! This re-exports the most frequently used domain types, core traits,
+//! configuration types, error types, and factory utilities so that
+//! consumers don't need to import from individual submodules.
+
+// Re-export domain types
+// pub use crate::domain::{
+//     Amount, BasisPoints, Decimals, FeeTier, Liquidity, LiquidityChange,
+//     Position, Price, Rounding, SwapResult, SwapSpec, Tick, Token,
+//     TokenAddress, TokenPair,
+// };
+
+// Re-export core traits
+// pub use crate::traits::{FromConfig, LiquidityPool, SwapPool};
+
+// Re-export math utilities
+// pub use crate::math::CheckedArithmetic;
+
+// Re-export configuration
+// pub use crate::config::AmmConfig;
+
+// Re-export error types
+// pub use crate::error::{AmmError, Result};
+
+// Re-export factory
+// pub use crate::factory::DefaultPoolFactory;
+
+// Re-export pool dispatch
+// pub use crate::pools::PoolBox;

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -1,0 +1,6 @@
+//! Core trait abstractions for AMM pool operations.
+//!
+//! This module defines the primary traits that all pool implementations
+//! must satisfy: `SwapPool` for executing swaps, `LiquidityPool`
+//! for managing positions, and `FromConfig` for configuration-driven
+//! pool construction.


### PR DESCRIPTION
## Summary

Create the full module structure for the `hydra-amm` crate by adding module declarations to `src/lib.rs` and creating documented stub files for all seven modules. This establishes the crate's architecture skeleton that subsequent issues will fill in.

## Changes

- **src/lib.rs**: Added `pub mod` declarations for all 7 modules: `config`, `domain`, `error`, `factory`, `math`, `pools`, `traits`
- **src/error.rs**: Stub with module-level documentation
- **src/domain/mod.rs**: Stub with module-level documentation
- **src/math/mod.rs**: Stub with module-level documentation
- **src/traits/mod.rs**: Stub with module-level documentation
- **src/config/mod.rs**: Stub with module-level documentation
- **src/pools/mod.rs**: Stub with module-level documentation
- **src/factory/mod.rs**: Stub with module-level documentation

## Technical Decisions

- **Stubs only**: Modules contain only `//!` doc comments. Actual types, traits, and implementations are created by subsequent issues (M2–M7).
- **Plain backticks for forward references**: Doc comments use backticks (`` `AmmError` ``) instead of intra-doc links (`[AmmError]`) since the types don't exist yet. This avoids rustdoc warnings while still being informative.
- **All modules always compiled**: No feature-gating on module declarations at this stage. Feature-gating will be applied to items within modules in later issues.
- **Module ordering**: Alphabetical in `lib.rs` declarations for consistency.

## Testing

- [x] Manual testing performed (`cargo test --all-features`)
- [x] `cargo check --all-features` passes
- [x] `cargo check --no-default-features` passes
- [x] `make pre-push` passes with zero warnings

## Checklist

- [x] Code follows `.internalDoc/09-RUST-GUIDELINES.md`
- [x] All public items have `///` documentation
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] Feature-gated code compiles with and without its feature
- [x] No `.unwrap()`, `.expect()`, or panics in library code

Closes #3
