### PR TITLE
M2 #5: Implement TokenAddress, Decimals, Token, TokenPair

### DIFF
--- a/src/domain/decimals.rs
+++ b/src/domain/decimals.rs
@@ -1,0 +1,193 @@
+//! Token decimal places.
+
+use crate::error::AmmError;
+
+/// Maximum allowed decimal places (EVM standard).
+const MAX_DECIMALS: u8 = 18;
+
+/// Represents the number of decimal places for a token amount.
+///
+/// Valid range is `0..=18`, matching the common blockchain standard.
+/// Construction is validated: values above 18 are rejected.
+///
+/// # Examples
+///
+/// ```
+/// use hydra_amm::domain::Decimals;
+///
+/// let d = Decimals::new(6).expect("6 is valid");
+/// assert_eq!(d.get(), 6);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Decimals(u8);
+
+impl Default for Decimals {
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
+impl Decimals {
+    /// Zero decimal places.
+    pub const ZERO: Self = Self(0);
+
+    /// Maximum standard decimal places (18).
+    pub const MAX: Self = Self(MAX_DECIMALS);
+
+    /// Creates a new `Decimals` value after validating the range.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AmmError::InvalidPrecision`] if `value` exceeds 18.
+    pub const fn new(value: u8) -> Result<Self, AmmError> {
+        if value > MAX_DECIMALS {
+            return Err(AmmError::InvalidPrecision("decimals must be 0..=18"));
+        }
+        Ok(Self(value))
+    }
+
+    /// Returns the raw decimal count.
+    #[must_use]
+    pub const fn get(&self) -> u8 {
+        self.0
+    }
+
+    /// Converts a human-readable amount to the smallest raw unit.
+    ///
+    /// For example, with `decimals = 6`, an input of `1` yields `1_000_000`.
+    ///
+    /// This operation cannot overflow because `u64::MAX * 10^18 < u128::MAX`.
+    #[must_use]
+    pub const fn scale_up(&self, amount: u64) -> u128 {
+        (amount as u128) * self.factor()
+    }
+
+    /// Converts raw units back to a human-readable amount.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AmmError::Overflow`] if the result does not fit in `u64`.
+    pub const fn scale_down(&self, raw: u128) -> Result<u64, AmmError> {
+        let result = raw / self.factor();
+        if result > u64::MAX as u128 {
+            return Err(AmmError::Overflow("scale_down result exceeds u64"));
+        }
+        Ok(result as u64)
+    }
+
+    /// Returns `10^decimals` as `u128`.
+    #[must_use]
+    const fn factor(&self) -> u128 {
+        10u128.pow(self.0 as u32)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_zero() {
+        let Ok(d) = Decimals::new(0) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(d.get(), 0);
+    }
+
+    #[test]
+    fn valid_six() {
+        let Ok(d) = Decimals::new(6) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(d.get(), 6);
+    }
+
+    #[test]
+    fn valid_eighteen() {
+        let Ok(d) = Decimals::new(18) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(d.get(), 18);
+    }
+
+    #[test]
+    fn invalid_nineteen() {
+        let Err(e) = Decimals::new(19) else {
+            panic!("expected Err");
+        };
+        assert_eq!(e, AmmError::InvalidPrecision("decimals must be 0..=18"));
+    }
+
+    #[test]
+    fn invalid_max_u8() {
+        let d = Decimals::new(u8::MAX);
+        assert!(d.is_err());
+    }
+
+    #[test]
+    fn constants() {
+        assert_eq!(Decimals::ZERO.get(), 0);
+        assert_eq!(Decimals::MAX.get(), 18);
+    }
+
+    #[test]
+    fn default_is_zero() {
+        assert_eq!(Decimals::default(), Decimals::ZERO);
+    }
+
+    #[test]
+    fn scale_up_usdc() {
+        let Ok(d) = Decimals::new(6) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(d.scale_up(1), 1_000_000);
+    }
+
+    #[test]
+    fn scale_up_eth() {
+        let Ok(d) = Decimals::new(18) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(d.scale_up(1), 1_000_000_000_000_000_000);
+    }
+
+    #[test]
+    fn scale_up_zero_decimals() {
+        let d = Decimals::ZERO;
+        assert_eq!(d.scale_up(42), 42);
+    }
+
+    #[test]
+    fn scale_down_usdc() {
+        let Ok(d) = Decimals::new(6) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(d.scale_down(1_000_000), Ok(1));
+    }
+
+    #[test]
+    fn scale_down_with_remainder_truncates() {
+        let Ok(d) = Decimals::new(6) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(d.scale_down(1_500_000), Ok(1));
+    }
+
+    #[test]
+    fn scale_round_trip() {
+        let Ok(d) = Decimals::new(8) else {
+            panic!("expected Ok");
+        };
+        let raw = d.scale_up(100);
+        assert_eq!(d.scale_down(raw), Ok(100));
+    }
+
+    #[test]
+    fn ordering() {
+        let (Ok(d6), Ok(d18)) = (Decimals::new(6), Decimals::new(18)) else {
+            panic!("expected Ok");
+        };
+        assert!(d6 < d18);
+    }
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -3,3 +3,13 @@
 //! This module contains the core value types that model the AMM domain:
 //! tokens, amounts, prices, ticks, positions, and swap specifications.
 //! All types use newtypes with validated constructors to enforce invariants.
+
+mod decimals;
+mod token;
+mod token_address;
+mod token_pair;
+
+pub use decimals::Decimals;
+pub use token::Token;
+pub use token_address::TokenAddress;
+pub use token_pair::TokenPair;

--- a/src/domain/token.rs
+++ b/src/domain/token.rs
@@ -1,0 +1,130 @@
+//! Token identity type.
+
+use super::{Decimals, TokenAddress};
+use crate::error::AmmError;
+
+/// The canonical identity of a token on a given chain.
+///
+/// Combines a [`TokenAddress`] with its [`Decimals`] to fully describe
+/// a token. Two tokens are considered equal only if both address and
+/// decimals match.
+///
+/// # Examples
+///
+/// ```
+/// use hydra_amm::domain::{Decimals, Token, TokenAddress};
+///
+/// let addr = TokenAddress::from_bytes([1u8; 32]);
+/// let dec  = Decimals::new(6).expect("valid");
+/// let tok  = Token::new(addr, dec);
+///
+/// assert_eq!(tok.address(), addr);
+/// assert_eq!(tok.decimals(), dec);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Token {
+    address: TokenAddress,
+    decimals: Decimals,
+}
+
+impl Token {
+    /// Creates a new `Token`.
+    ///
+    /// Construction is infallible because both components are already
+    /// validated at their own construction site.
+    #[must_use]
+    pub const fn new(address: TokenAddress, decimals: Decimals) -> Self {
+        Self { address, decimals }
+    }
+
+    /// Returns the token address.
+    #[must_use]
+    pub const fn address(&self) -> TokenAddress {
+        self.address
+    }
+
+    /// Returns the token decimals.
+    #[must_use]
+    pub const fn decimals(&self) -> Decimals {
+        self.decimals
+    }
+
+    /// Converts a human-readable amount to the smallest raw unit
+    /// for this token.
+    ///
+    /// For example, `1` USDC (decimals=6) becomes `1_000_000`.
+    #[must_use]
+    pub const fn to_raw_amount(&self, human: u64) -> u128 {
+        self.decimals.scale_up(human)
+    }
+
+    /// Converts raw units back to a human-readable amount for this token.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AmmError::Overflow`] if the result does not fit in `u64`.
+    pub const fn from_raw_amount(&self, raw: u128) -> Result<u64, AmmError> {
+        self.decimals.scale_down(raw)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic)]
+mod tests {
+    use super::*;
+
+    fn sample_token(addr_byte: u8, dec: u8) -> Token {
+        let Ok(d) = Decimals::new(dec) else {
+            panic!("invalid decimals in test: {dec}");
+        };
+        Token::new(TokenAddress::from_bytes([addr_byte; 32]), d)
+    }
+
+    #[test]
+    fn accessors() {
+        let tok = sample_token(1, 6);
+        assert_eq!(tok.address(), TokenAddress::from_bytes([1u8; 32]));
+        assert_eq!(tok.decimals().get(), 6);
+    }
+
+    #[test]
+    fn to_raw_amount_usdc() {
+        let tok = sample_token(1, 6);
+        assert_eq!(tok.to_raw_amount(5), 5_000_000);
+    }
+
+    #[test]
+    fn from_raw_amount_usdc() {
+        let tok = sample_token(1, 6);
+        assert_eq!(tok.from_raw_amount(5_000_000), Ok(5));
+    }
+
+    #[test]
+    fn round_trip() {
+        let tok = sample_token(1, 18);
+        let raw = tok.to_raw_amount(100);
+        let human = tok.from_raw_amount(raw);
+        assert_eq!(human, Ok(100));
+    }
+
+    #[test]
+    fn equality_requires_both_fields() {
+        let a = sample_token(1, 6);
+        let b = sample_token(1, 8);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn same_token_is_equal() {
+        let a = sample_token(1, 6);
+        let b = sample_token(1, 6);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn copy_semantics() {
+        let a = sample_token(1, 6);
+        let b = a;
+        assert_eq!(a, b);
+    }
+}

--- a/src/domain/token_address.rs
+++ b/src/domain/token_address.rs
@@ -1,0 +1,92 @@
+//! Chain-agnostic token address.
+
+/// A generic, chain-agnostic address representing a token on any blockchain.
+///
+/// Wraps a fixed-size `[u8; 32]` byte array. All 32-byte sequences are
+/// considered valid addresses, so construction is infallible.
+///
+/// # Examples
+///
+/// ```
+/// use hydra_amm::domain::TokenAddress;
+///
+/// let addr = TokenAddress::from_bytes([1u8; 32]);
+/// assert_eq!(addr.as_bytes(), [1u8; 32]);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TokenAddress([u8; 32]);
+
+impl TokenAddress {
+    /// Creates a `TokenAddress` from raw bytes.
+    #[must_use]
+    pub const fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// Returns the underlying 32-byte representation.
+    #[must_use]
+    pub const fn as_bytes(&self) -> [u8; 32] {
+        self.0
+    }
+
+    /// Returns the all-zero address.
+    ///
+    /// Useful as a sentinel or placeholder value; use sparingly.
+    #[must_use]
+    pub const fn zero() -> Self {
+        Self([0u8; 32])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_bytes_round_trip() {
+        let bytes = [42u8; 32];
+        let addr = TokenAddress::from_bytes(bytes);
+        assert_eq!(addr.as_bytes(), bytes);
+    }
+
+    #[test]
+    fn zero_is_all_zeros() {
+        let addr = TokenAddress::zero();
+        assert_eq!(addr.as_bytes(), [0u8; 32]);
+    }
+
+    #[test]
+    fn equality_same_bytes() {
+        let a = TokenAddress::from_bytes([1u8; 32]);
+        let b = TokenAddress::from_bytes([1u8; 32]);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn inequality_different_bytes() {
+        let a = TokenAddress::from_bytes([1u8; 32]);
+        let b = TokenAddress::from_bytes([2u8; 32]);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn ordering_is_lexicographic() {
+        let lo = TokenAddress::from_bytes([0u8; 32]);
+        let hi = TokenAddress::from_bytes([1u8; 32]);
+        assert!(lo < hi);
+    }
+
+    #[test]
+    fn copy_semantics() {
+        let a = TokenAddress::from_bytes([5u8; 32]);
+        let b = a;
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn debug_format() {
+        let addr = TokenAddress::zero();
+        let dbg = format!("{addr:?}");
+        assert!(dbg.contains("TokenAddress"));
+    }
+}

--- a/src/domain/token_pair.rs
+++ b/src/domain/token_pair.rs
@@ -1,0 +1,219 @@
+//! Ordered pair of distinct tokens.
+
+use super::Token;
+use crate::error::AmmError;
+
+/// An ordered pair of distinct tokens, canonically sorted by address.
+///
+/// The canonical ordering guarantees that `token_a.address() < token_b.address()`,
+/// preventing duplicate pairs such as `(A, B)` and `(B, A)`.
+///
+/// # Examples
+///
+/// ```
+/// use hydra_amm::domain::{Decimals, Token, TokenAddress, TokenPair};
+///
+/// let tok_a = Token::new(TokenAddress::from_bytes([1u8; 32]), Decimals::new(6).expect("valid"));
+/// let tok_b = Token::new(TokenAddress::from_bytes([2u8; 32]), Decimals::new(18).expect("valid"));
+///
+/// // Order is enforced automatically:
+/// let pair = TokenPair::new(tok_b, tok_a).expect("distinct tokens");
+/// assert_eq!(pair.first(), tok_a);
+/// assert_eq!(pair.second(), tok_b);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TokenPair {
+    token_a: Token,
+    token_b: Token,
+}
+
+impl TokenPair {
+    /// Creates a new canonically-ordered `TokenPair`.
+    ///
+    /// The two tokens are automatically sorted so that
+    /// `token_a.address() < token_b.address()`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AmmError::InvalidToken`] if both tokens have the same address.
+    pub fn new(token1: Token, token2: Token) -> Result<Self, AmmError> {
+        if token1.address() == token2.address() {
+            return Err(AmmError::InvalidToken(
+                "token pair requires two distinct addresses",
+            ));
+        }
+
+        let (token_a, token_b) = if token1.address() < token2.address() {
+            (token1, token2)
+        } else {
+            (token2, token1)
+        };
+
+        Ok(Self { token_a, token_b })
+    }
+
+    /// Returns the first token (lower address).
+    #[must_use]
+    pub const fn first(&self) -> Token {
+        self.token_a
+    }
+
+    /// Returns the second token (higher address).
+    #[must_use]
+    pub const fn second(&self) -> Token {
+        self.token_b
+    }
+
+    /// Returns `true` if the given token is part of this pair.
+    #[must_use]
+    pub fn contains(&self, token: &Token) -> bool {
+        self.token_a == *token || self.token_b == *token
+    }
+
+    /// Returns the counterpart of `token` in this pair.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AmmError::InvalidToken`] if `token` is not in the pair.
+    pub fn other(&self, token: &Token) -> Result<Token, AmmError> {
+        if *token == self.token_a {
+            Ok(self.token_b)
+        } else if *token == self.token_b {
+            Ok(self.token_a)
+        } else {
+            Err(AmmError::InvalidToken("token is not part of this pair"))
+        }
+    }
+
+    /// Returns `true` if the pair is in canonical order.
+    ///
+    /// Always returns `true` for a validly constructed `TokenPair`.
+    #[must_use]
+    pub fn is_ordered_correctly(&self) -> bool {
+        self.token_a.address() < self.token_b.address()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic)]
+mod tests {
+    use super::*;
+    use crate::domain::{Decimals, TokenAddress};
+
+    fn tok(addr_byte: u8, dec: u8) -> Token {
+        let Ok(d) = Decimals::new(dec) else {
+            panic!("invalid decimals in test: {dec}");
+        };
+        Token::new(TokenAddress::from_bytes([addr_byte; 32]), d)
+    }
+
+    #[test]
+    fn valid_pair_preserves_order() {
+        let a = tok(1, 6);
+        let b = tok(2, 18);
+        let Ok(pair) = TokenPair::new(a, b) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(pair.first(), a);
+        assert_eq!(pair.second(), b);
+    }
+
+    #[test]
+    fn auto_sorts_reversed_input() {
+        let a = tok(1, 6);
+        let b = tok(2, 18);
+        let Ok(pair) = TokenPair::new(b, a) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(pair.first(), a);
+        assert_eq!(pair.second(), b);
+        assert!(pair.is_ordered_correctly());
+    }
+
+    #[test]
+    fn rejects_same_address() {
+        let a = tok(1, 6);
+        let b = tok(1, 18);
+        let Err(e) = TokenPair::new(a, b) else {
+            panic!("expected Err");
+        };
+        assert_eq!(
+            e,
+            AmmError::InvalidToken("token pair requires two distinct addresses")
+        );
+    }
+
+    #[test]
+    fn contains_first() {
+        let a = tok(1, 6);
+        let b = tok(2, 18);
+        let Ok(pair) = TokenPair::new(a, b) else {
+            panic!("expected Ok");
+        };
+        assert!(pair.contains(&a));
+    }
+
+    #[test]
+    fn contains_second() {
+        let a = tok(1, 6);
+        let b = tok(2, 18);
+        let Ok(pair) = TokenPair::new(a, b) else {
+            panic!("expected Ok");
+        };
+        assert!(pair.contains(&b));
+    }
+
+    #[test]
+    fn does_not_contain_foreign() {
+        let a = tok(1, 6);
+        let b = tok(2, 18);
+        let c = tok(3, 8);
+        let Ok(pair) = TokenPair::new(a, b) else {
+            panic!("expected Ok");
+        };
+        assert!(!pair.contains(&c));
+    }
+
+    #[test]
+    fn other_returns_counterpart() {
+        let a = tok(1, 6);
+        let b = tok(2, 18);
+        let Ok(pair) = TokenPair::new(a, b) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(pair.other(&a), Ok(b));
+        assert_eq!(pair.other(&b), Ok(a));
+    }
+
+    #[test]
+    fn other_rejects_foreign() {
+        let a = tok(1, 6);
+        let b = tok(2, 18);
+        let c = tok(3, 8);
+        let Ok(pair) = TokenPair::new(a, b) else {
+            panic!("expected Ok");
+        };
+        assert!(pair.other(&c).is_err());
+    }
+
+    #[test]
+    fn equality_of_pairs() {
+        let a = tok(1, 6);
+        let b = tok(2, 18);
+        let (Ok(p1), Ok(p2)) = (TokenPair::new(a, b), TokenPair::new(b, a)) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(p1, p2);
+    }
+
+    #[test]
+    fn copy_semantics() {
+        let a = tok(1, 6);
+        let b = tok(2, 18);
+        let Ok(p) = TokenPair::new(a, b) else {
+            panic!("expected Ok");
+        };
+        let p2 = p;
+        assert_eq!(p, p2);
+    }
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -11,12 +11,8 @@
 //! configuration types, error types, and factory utilities so that
 //! consumers don't need to import from individual submodules.
 
-// Re-export domain types
-// pub use crate::domain::{
-//     Amount, BasisPoints, Decimals, FeeTier, Liquidity, LiquidityChange,
-//     Position, Price, Rounding, SwapResult, SwapSpec, Tick, Token,
-//     TokenAddress, TokenPair,
-// };
+// Re-export domain types (types added incrementally as they are implemented)
+pub use crate::domain::{Decimals, Token, TokenAddress, TokenPair};
 
 // Re-export core traits
 // pub use crate::traits::{FromConfig, LiquidityPool, SwapPool};


### PR DESCRIPTION
## Summary

Implement the four core token domain types as newtypes with validated constructors, following the spec in `.internalDoc/01-DOMAIN-MODEL.md`. These are the foundational identity types used by every other module in the crate.

## Changes

- **src/domain/token_address.rs**: `TokenAddress` newtype over `[u8; 32]` — `from_bytes()`, `as_bytes()`, `zero()`, derives `Ord` for canonical pair ordering
- **src/domain/decimals.rs**: `Decimals` newtype over `u8` — validated `new()` (0..=18), `ZERO`/`MAX` constants, `scale_up()` (u64→u128), `scale_down()` (u128→Result<u64>)
- **src/domain/token.rs**: `Token` struct — infallible `new(address, decimals)`, `to_raw_amount()`, `from_raw_amount()` with overflow protection
- **src/domain/token_pair.rs**: `TokenPair` struct — validated `new()` rejects same-address pairs, auto-sorts canonically, `contains()`, `other()`, `is_ordered_correctly()`
- **src/domain/mod.rs**: Submodule declarations and public re-exports
- **src/prelude.rs**: Added `Decimals`, `Token`, `TokenAddress`, `TokenPair` re-exports

## Technical Decisions

- **`&'static str` context in errors**: All validation errors use `&'static str` for `no_std` compatibility (e.g., `AmmError::InvalidPrecision("decimals must be 0..=18")`)
- **`scale_down` returns `Result`**: Unlike the spec's `u64` return, we return `Result<u64, AmmError>` to avoid panics when the truncated result exceeds `u64::MAX`
- **`TokenAddress` derives `Ord`**: Required for canonical `TokenPair` ordering (`token_a.address() < token_b.address()`)
- **`Token` does NOT derive `Ord`**: Ordering tokens is domain-ambiguous; only `TokenAddress` ordering is used
- **`#[allow(clippy::panic)]` in test modules**: The Cargo.toml denies `panic` and `expect_used` globally; test modules need the allow attribute for `let-else` patterns

## Testing

- [x] Unit tests added (38 new tests across 4 modules)
  - TokenAddress: 7 tests (from_bytes, as_bytes, zero, equality, ordering, copy, debug)
  - Decimals: 14 tests (valid/invalid construction, constants, default, scale_up, scale_down, round trip, ordering)
  - Token: 7 tests (accessors, to_raw/from_raw, round trip, equality, copy)
  - TokenPair: 10 tests (valid pairs, auto-sort, same-address rejection, contains, other, equality, copy)
- [x] Doc-tests added (4 new doc-tests)
- [x] Manual testing performed (`cargo test --all-features` — 49 passed, 5 doc-tests passed)

## Checklist

- [x] Code follows `.internalDoc/09-RUST-GUIDELINES.md`
- [x] All public items have `///` documentation
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] Feature-gated code compiles with and without its feature
- [x] No `.unwrap()`, `.expect()`, or panics in library code

Closes #5
