### PR TITLE
M2 #7: Implement Liquidity, BasisPoints, FeeTier

### DIFF
--- a/src/domain/basis_points.rs
+++ b/src/domain/basis_points.rs
@@ -1,0 +1,244 @@
+//! Basis-point representation for percentages.
+
+use core::fmt;
+
+use super::{Amount, Rounding};
+use crate::error::AmmError;
+
+/// Maximum value that represents 100%.
+const MAX_BPS: u32 = 10_000;
+
+/// A percentage expressed in basis points (1 bp = 0.01%, 10 000 bp = 100%).
+///
+/// All `u32` values are technically valid, but values above 10 000 are
+/// nonsensical as percentages. Use [`is_valid_percent`](Self::is_valid_percent)
+/// to check.
+///
+/// # Examples
+///
+/// ```
+/// use hydra_amm::domain::BasisPoints;
+///
+/// let bp = BasisPoints::new(30);
+/// assert_eq!(bp.get(), 30);
+/// assert!(bp.is_valid_percent());
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct BasisPoints(u32);
+
+impl BasisPoints {
+    /// Zero basis points (0%).
+    pub const ZERO: Self = Self(0);
+
+    /// 100% expressed in basis points.
+    pub const MAX_PERCENT: Self = Self(MAX_BPS);
+
+    /// Creates a new `BasisPoints` from a raw `u32` value.
+    pub const fn new(value: u32) -> Self {
+        Self(value)
+    }
+
+    /// Returns the underlying `u32` value.
+    #[must_use]
+    pub const fn get(&self) -> u32 {
+        self.0
+    }
+
+    /// Returns `true` if the value is in the valid percentage range (`0..=10_000`).
+    #[must_use]
+    pub const fn is_valid_percent(&self) -> bool {
+        self.0 <= MAX_BPS
+    }
+
+    /// Converts to a floating-point percentage in the range `0.0..=100.0`.
+    ///
+    /// For example, 30 bp → 0.30%.
+    #[must_use]
+    pub fn as_percent(&self) -> f64 {
+        self.0 as f64 / 100.0
+    }
+
+    /// Computes `amount * (self / 10_000)` with explicit rounding.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AmmError::Overflow`] if the intermediate multiplication overflows.
+    pub const fn apply(&self, amount: Amount, rounding: Rounding) -> crate::error::Result<Amount> {
+        let bps = self.0 as u128;
+        let raw = amount.get();
+
+        let product = match raw.checked_mul(bps) {
+            Some(v) => v,
+            None => return Err(AmmError::Overflow("basis points apply overflow")),
+        };
+
+        let divisor = MAX_BPS as u128;
+
+        match rounding {
+            Rounding::Down => Ok(Amount::new(product / divisor)),
+            Rounding::Up => {
+                // Ceiling: (product + divisor - 1) / divisor
+                // divisor is 10_000, so (divisor - 1) is small; overflow here
+                // is only possible when product is extremely close to u128::MAX.
+                match product.checked_add(divisor - 1) {
+                    Some(n) => Ok(Amount::new(n / divisor)),
+                    None => {
+                        let q = product / divisor;
+                        let r = product % divisor;
+                        if r != 0 {
+                            Ok(Amount::new(q + 1))
+                        } else {
+                            Ok(Amount::new(q))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl fmt::Display for BasisPoints {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}bp", self.0)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_and_get() {
+        assert_eq!(BasisPoints::new(30).get(), 30);
+    }
+
+    #[test]
+    fn constants() {
+        assert_eq!(BasisPoints::ZERO.get(), 0);
+        assert_eq!(BasisPoints::MAX_PERCENT.get(), 10_000);
+    }
+
+    #[test]
+    fn default_is_zero() {
+        assert_eq!(BasisPoints::default(), BasisPoints::ZERO);
+    }
+
+    #[test]
+    fn is_valid_percent_in_range() {
+        assert!(BasisPoints::ZERO.is_valid_percent());
+        assert!(BasisPoints::new(5_000).is_valid_percent());
+        assert!(BasisPoints::MAX_PERCENT.is_valid_percent());
+    }
+
+    #[test]
+    fn is_valid_percent_out_of_range() {
+        assert!(!BasisPoints::new(10_001).is_valid_percent());
+        assert!(!BasisPoints::new(u32::MAX).is_valid_percent());
+    }
+
+    #[test]
+    fn as_percent_thirty_bp() {
+        let bp = BasisPoints::new(30);
+        let pct = bp.as_percent();
+        assert!((pct - 0.30).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn as_percent_one_hundred() {
+        let bp = BasisPoints::MAX_PERCENT;
+        let pct = bp.as_percent();
+        assert!((pct - 100.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn display() {
+        assert_eq!(format!("{}", BasisPoints::new(30)), "30bp");
+    }
+
+    #[test]
+    fn ordering() {
+        assert!(BasisPoints::new(1) < BasisPoints::new(5));
+    }
+
+    // -- apply --------------------------------------------------------------
+
+    #[test]
+    fn apply_round_down() {
+        // 30bp of 1_000_000 = 1_000_000 * 30 / 10_000 = 3_000
+        let bp = BasisPoints::new(30);
+        let amount = Amount::new(1_000_000);
+        let Ok(result) = bp.apply(amount, Rounding::Down) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(result, Amount::new(3_000));
+    }
+
+    #[test]
+    fn apply_round_up_exact() {
+        // 100bp of 10_000 = 10_000 * 100 / 10_000 = 100 (exact)
+        let bp = BasisPoints::new(100);
+        let amount = Amount::new(10_000);
+        let Ok(result) = bp.apply(amount, Rounding::Up) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(result, Amount::new(100));
+    }
+
+    #[test]
+    fn apply_round_up_remainder() {
+        // 30bp of 1 = 1 * 30 / 10_000 = 0.003 → ceil = 1
+        let bp = BasisPoints::new(30);
+        let amount = Amount::new(1);
+        let Ok(result) = bp.apply(amount, Rounding::Up) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(result, Amount::new(1));
+    }
+
+    #[test]
+    fn apply_round_down_remainder() {
+        // 30bp of 1 = 1 * 30 / 10_000 = 0.003 → floor = 0
+        let bp = BasisPoints::new(30);
+        let amount = Amount::new(1);
+        let Ok(result) = bp.apply(amount, Rounding::Down) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(result, Amount::ZERO);
+    }
+
+    #[test]
+    fn apply_zero_amount() {
+        let bp = BasisPoints::new(30);
+        let Ok(result) = bp.apply(Amount::ZERO, Rounding::Down) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(result, Amount::ZERO);
+    }
+
+    #[test]
+    fn apply_zero_bp() {
+        let bp = BasisPoints::ZERO;
+        let Ok(result) = bp.apply(Amount::new(1_000_000), Rounding::Down) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(result, Amount::ZERO);
+    }
+
+    #[test]
+    fn apply_overflow() {
+        let bp = BasisPoints::new(u32::MAX);
+        let amount = Amount::MAX;
+        let result = bp.apply(amount, Rounding::Down);
+        assert!(result.is_err());
+    }
+
+    // -- Copy ---------------------------------------------------------------
+
+    #[test]
+    fn copy_semantics() {
+        let a = BasisPoints::new(30);
+        let b = a;
+        assert_eq!(a, b);
+    }
+}

--- a/src/domain/fee_tier.rs
+++ b/src/domain/fee_tier.rs
@@ -1,0 +1,167 @@
+//! Protocol fee tiers built on [`BasisPoints`].
+
+use core::fmt;
+
+use super::{Amount, BasisPoints, Rounding};
+
+/// A protocol-specific fee tier wrapping [`BasisPoints`] with common presets.
+///
+/// Any `BasisPoints` value is accepted, but [`is_standard`](Self::is_standard)
+/// indicates whether it matches one of the four well-known tiers used across
+/// major AMM protocols.
+///
+/// # Examples
+///
+/// ```
+/// use hydra_amm::domain::{BasisPoints, FeeTier};
+///
+/// let tier = FeeTier::TIER_0_30_PERCENT;
+/// assert_eq!(tier.basis_points().get(), 30);
+/// assert!(tier.is_standard());
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct FeeTier(BasisPoints);
+
+impl FeeTier {
+    /// 0.01% fee — ultra-concentrated, low-volume pairs (1 bp).
+    pub const TIER_0_01_PERCENT: Self = Self(BasisPoints::new(1));
+
+    /// 0.05% fee — stablecoin pairs (5 bp).
+    pub const TIER_0_05_PERCENT: Self = Self(BasisPoints::new(5));
+
+    /// 0.30% fee — standard volatile pairs (30 bp).
+    pub const TIER_0_30_PERCENT: Self = Self(BasisPoints::new(30));
+
+    /// 1.00% fee — high-fee trading pairs (100 bp).
+    pub const TIER_1_00_PERCENT: Self = Self(BasisPoints::new(100));
+
+    /// Creates a new `FeeTier` from arbitrary [`BasisPoints`].
+    pub const fn new(basis_points: BasisPoints) -> Self {
+        Self(basis_points)
+    }
+
+    /// Returns the underlying [`BasisPoints`].
+    #[must_use]
+    pub const fn basis_points(&self) -> BasisPoints {
+        self.0
+    }
+
+    /// Computes the fee for a given `amount` using this tier's basis points.
+    ///
+    /// Delegates to [`BasisPoints::apply`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AmmError::Overflow`](crate::error::AmmError::Overflow) if the intermediate multiplication overflows.
+    pub const fn apply_to_amount(
+        &self,
+        amount: Amount,
+        rounding: Rounding,
+    ) -> crate::error::Result<Amount> {
+        self.0.apply(amount, rounding)
+    }
+
+    /// Returns `true` if this tier matches one of the four standard presets.
+    #[must_use]
+    pub const fn is_standard(&self) -> bool {
+        matches!(self.0.get(), 1 | 5 | 30 | 100)
+    }
+}
+
+impl fmt::Display for FeeTier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "FeeTier({})", self.0)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic)]
+mod tests {
+    use super::*;
+
+    // -- Construction & accessors -------------------------------------------
+
+    #[test]
+    fn new_and_basis_points() {
+        let tier = FeeTier::new(BasisPoints::new(42));
+        assert_eq!(tier.basis_points().get(), 42);
+    }
+
+    #[test]
+    fn preset_values() {
+        assert_eq!(FeeTier::TIER_0_01_PERCENT.basis_points().get(), 1);
+        assert_eq!(FeeTier::TIER_0_05_PERCENT.basis_points().get(), 5);
+        assert_eq!(FeeTier::TIER_0_30_PERCENT.basis_points().get(), 30);
+        assert_eq!(FeeTier::TIER_1_00_PERCENT.basis_points().get(), 100);
+    }
+
+    // -- is_standard --------------------------------------------------------
+
+    #[test]
+    fn standard_tiers() {
+        assert!(FeeTier::TIER_0_01_PERCENT.is_standard());
+        assert!(FeeTier::TIER_0_05_PERCENT.is_standard());
+        assert!(FeeTier::TIER_0_30_PERCENT.is_standard());
+        assert!(FeeTier::TIER_1_00_PERCENT.is_standard());
+    }
+
+    #[test]
+    fn non_standard_tier() {
+        let tier = FeeTier::new(BasisPoints::new(42));
+        assert!(!tier.is_standard());
+    }
+
+    // -- apply_to_amount ----------------------------------------------------
+
+    #[test]
+    fn apply_30bp_round_down() {
+        // 30bp of 1_000_000 = 3_000
+        let tier = FeeTier::TIER_0_30_PERCENT;
+        let Ok(fee) = tier.apply_to_amount(Amount::new(1_000_000), Rounding::Down) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(fee, Amount::new(3_000));
+    }
+
+    #[test]
+    fn apply_1bp_round_up_remainder() {
+        // 1bp of 1 = 1 * 1 / 10_000 = 0.0001 → ceil = 1
+        let tier = FeeTier::TIER_0_01_PERCENT;
+        let Ok(fee) = tier.apply_to_amount(Amount::new(1), Rounding::Up) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(fee, Amount::new(1));
+    }
+
+    #[test]
+    fn apply_zero_amount() {
+        let tier = FeeTier::TIER_0_30_PERCENT;
+        let Ok(fee) = tier.apply_to_amount(Amount::ZERO, Rounding::Down) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(fee, Amount::ZERO);
+    }
+
+    // -- Display ------------------------------------------------------------
+
+    #[test]
+    fn display() {
+        assert_eq!(format!("{}", FeeTier::TIER_0_30_PERCENT), "FeeTier(30bp)");
+    }
+
+    // -- Ordering -----------------------------------------------------------
+
+    #[test]
+    fn ordering() {
+        assert!(FeeTier::TIER_0_01_PERCENT < FeeTier::TIER_1_00_PERCENT);
+    }
+
+    // -- Copy ---------------------------------------------------------------
+
+    #[test]
+    fn copy_semantics() {
+        let a = FeeTier::TIER_0_30_PERCENT;
+        let b = a;
+        assert_eq!(a, b);
+    }
+}

--- a/src/domain/liquidity.rs
+++ b/src/domain/liquidity.rs
@@ -1,0 +1,190 @@
+//! Liquidity units for concentrated positions.
+
+use core::fmt;
+
+use super::Amount;
+
+/// Liquidity units in a concentrated position.
+///
+/// This is distinct from [`Amount`] because it measures the amount of
+/// liquidity available in a price range, not the amount of a specific token.
+/// All `u128` values are valid liquidity amounts.
+///
+/// # Examples
+///
+/// ```
+/// use hydra_amm::domain::Liquidity;
+///
+/// let a = Liquidity::new(1_000);
+/// let b = Liquidity::new(2_000);
+/// assert_eq!(a.checked_add(&b), Some(Liquidity::new(3_000)));
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Liquidity(u128);
+
+impl Liquidity {
+    /// No liquidity.
+    pub const ZERO: Self = Self(0);
+
+    /// Creates a new `Liquidity` from a raw `u128` value.
+    pub const fn new(value: u128) -> Self {
+        Self(value)
+    }
+
+    /// Returns the underlying `u128` value.
+    #[must_use]
+    pub const fn get(&self) -> u128 {
+        self.0
+    }
+
+    /// Returns `true` if the liquidity is zero.
+    #[must_use]
+    pub const fn is_zero(&self) -> bool {
+        self.0 == 0
+    }
+
+    /// Checked addition. Returns `None` on overflow.
+    #[must_use]
+    pub const fn checked_add(&self, other: &Self) -> Option<Self> {
+        match self.0.checked_add(other.0) {
+            Some(v) => Some(Self(v)),
+            None => None,
+        }
+    }
+
+    /// Checked subtraction. Returns `None` on underflow.
+    #[must_use]
+    pub const fn checked_sub(&self, other: &Self) -> Option<Self> {
+        match self.0.checked_sub(other.0) {
+            Some(v) => Some(Self(v)),
+            None => None,
+        }
+    }
+
+    /// Scales an [`Amount`] by this liquidity value.
+    ///
+    /// Returns `None` on overflow.
+    #[must_use]
+    pub const fn checked_mul_amount(&self, amount: &Amount) -> Option<Amount> {
+        match self.0.checked_mul(amount.get()) {
+            Some(v) => Some(Amount::new(v)),
+            None => None,
+        }
+    }
+}
+
+impl fmt::Display for Liquidity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_and_get() {
+        assert_eq!(Liquidity::new(42).get(), 42);
+    }
+
+    #[test]
+    fn zero_constant() {
+        assert_eq!(Liquidity::ZERO.get(), 0);
+        assert!(Liquidity::ZERO.is_zero());
+    }
+
+    #[test]
+    fn default_is_zero() {
+        assert_eq!(Liquidity::default(), Liquidity::ZERO);
+    }
+
+    #[test]
+    fn is_zero_false() {
+        assert!(!Liquidity::new(1).is_zero());
+    }
+
+    #[test]
+    fn display() {
+        assert_eq!(format!("{}", Liquidity::new(1_000)), "1000");
+    }
+
+    #[test]
+    fn ordering() {
+        assert!(Liquidity::new(1) < Liquidity::new(2));
+    }
+
+    // -- checked_add --------------------------------------------------------
+
+    #[test]
+    fn add_normal() {
+        let a = Liquidity::new(100);
+        let b = Liquidity::new(200);
+        assert_eq!(a.checked_add(&b), Some(Liquidity::new(300)));
+    }
+
+    #[test]
+    fn add_zero() {
+        let a = Liquidity::new(42);
+        assert_eq!(a.checked_add(&Liquidity::ZERO), Some(a));
+    }
+
+    #[test]
+    fn add_overflow() {
+        let a = Liquidity::new(u128::MAX);
+        assert_eq!(a.checked_add(&Liquidity::new(1)), None);
+    }
+
+    // -- checked_sub --------------------------------------------------------
+
+    #[test]
+    fn sub_normal() {
+        let a = Liquidity::new(300);
+        let b = Liquidity::new(100);
+        assert_eq!(a.checked_sub(&b), Some(Liquidity::new(200)));
+    }
+
+    #[test]
+    fn sub_to_zero() {
+        let a = Liquidity::new(42);
+        assert_eq!(a.checked_sub(&a), Some(Liquidity::ZERO));
+    }
+
+    #[test]
+    fn sub_underflow() {
+        let a = Liquidity::new(1);
+        assert_eq!(a.checked_sub(&Liquidity::new(2)), None);
+    }
+
+    // -- checked_mul_amount -------------------------------------------------
+
+    #[test]
+    fn mul_amount_normal() {
+        let l = Liquidity::new(100);
+        let a = Amount::new(50);
+        assert_eq!(l.checked_mul_amount(&a), Some(Amount::new(5_000)));
+    }
+
+    #[test]
+    fn mul_amount_zero() {
+        let l = Liquidity::new(100);
+        assert_eq!(l.checked_mul_amount(&Amount::ZERO), Some(Amount::ZERO));
+    }
+
+    #[test]
+    fn mul_amount_overflow() {
+        let l = Liquidity::new(u128::MAX);
+        let a = Amount::new(2);
+        assert_eq!(l.checked_mul_amount(&a), None);
+    }
+
+    // -- Copy ---------------------------------------------------------------
+
+    #[test]
+    fn copy_semantics() {
+        let a = Liquidity::new(99);
+        let b = a;
+        assert_eq!(a, b);
+    }
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -5,14 +5,20 @@
 //! All types use newtypes with validated constructors to enforce invariants.
 
 mod amount;
+mod basis_points;
 mod decimals;
+mod fee_tier;
+mod liquidity;
 mod rounding;
 mod token;
 mod token_address;
 mod token_pair;
 
 pub use amount::Amount;
+pub use basis_points::BasisPoints;
 pub use decimals::Decimals;
+pub use fee_tier::FeeTier;
+pub use liquidity::Liquidity;
 pub use rounding::Rounding;
 pub use token::Token;
 pub use token_address::TokenAddress;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -12,7 +12,9 @@
 //! consumers don't need to import from individual submodules.
 
 // Re-export domain types (types added incrementally as they are implemented)
-pub use crate::domain::{Amount, Decimals, Rounding, Token, TokenAddress, TokenPair};
+pub use crate::domain::{
+    Amount, BasisPoints, Decimals, FeeTier, Liquidity, Rounding, Token, TokenAddress, TokenPair,
+};
 
 // Re-export core traits
 // pub use crate::traits::{FromConfig, LiquidityPool, SwapPool};


### PR DESCRIPTION
## Summary

Implement three domain types for fee and liquidity modeling: `Liquidity` (pool liquidity units), `BasisPoints` (percentage in basis points), and `FeeTier` (protocol fee presets). These are used by pool implementations for fee calculation and liquidity tracking.

## Changes

- **src/domain/liquidity.rs**: `Liquidity` newtype over `u128`
  - Constants: `ZERO`
  - Methods: `new()`, `get()`, `is_zero()`, `Display`
  - Checked arithmetic: `checked_add`, `checked_sub`, `checked_mul_amount` (scales an `Amount` by liquidity)
  - Derives: `Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default`
- **src/domain/basis_points.rs**: `BasisPoints` newtype over `u32`
  - Constants: `ZERO`, `MAX_PERCENT` (10,000)
  - Methods: `new()`, `get()`, `is_valid_percent()`, `as_percent()`, `Display`
  - `apply(amount, rounding) -> Result<Amount, AmmError>` with overflow-safe ceiling division
  - Derives: `Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default`
- **src/domain/fee_tier.rs**: `FeeTier` newtype over `BasisPoints`
  - 4 preset constants: `TIER_0_01_PERCENT` (1bp), `TIER_0_05_PERCENT` (5bp), `TIER_0_30_PERCENT` (30bp), `TIER_1_00_PERCENT` (100bp)
  - Methods: `new()`, `basis_points()`, `apply_to_amount()` (delegates to `BasisPoints::apply`), `is_standard()`, `Display`
  - Derives: `Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash`
- **src/domain/mod.rs**: Added submodule declarations and re-exports
- **src/prelude.rs**: Added `BasisPoints`, `FeeTier`, `Liquidity` re-exports

## Technical Decisions

- **`BasisPoints` wraps `u32`** (per spec): The issue body suggested `u16`, but the spec in `01-DOMAIN-MODEL.md` specifies `u32`. All `u32` values are technically valid — `is_valid_percent()` provides a soft check for the 0..=10,000 range.
- **`BasisPoints::apply` returns `Result`**: The spec shows `apply` returning `Result<Amount, ArithmeticError>`. We use `AmmError::Overflow` since `AmmError` is our unified error type.
- **Overflow-safe ceiling division in `apply`**: Same pattern as `Amount::checked_div` — detects `(product + divisor - 1)` overflow and falls back to `floor + (remainder != 0)`.
- **`FeeTier` does not derive `Default`**: Unlike `Liquidity` and `BasisPoints`, there's no sensible default fee tier.
- **`Liquidity` has no `MAX` constant**: Per spec, only `ZERO` is defined. `Amount` has `MAX` because it's used as a sentinel; liquidity has no such use case.

## Testing

- [x] Unit tests added (43 new tests across 3 modules)
  - Liquidity: 16 tests (construction, constants, default, display, ordering, checked_add/sub, checked_mul_amount, copy)
  - BasisPoints: 18 tests (construction, constants, default, is_valid_percent, as_percent, display, ordering, apply with both roundings, edge cases, overflow, copy)
  - FeeTier: 9 tests (construction, preset values, is_standard, apply_to_amount, display, ordering, copy)
- [x] Doc-tests added (3 new)
- [x] Manual testing performed (`cargo test --all-features` — 125 passed, 10 doc-tests passed)

## Checklist

- [x] Code follows `.internalDoc/09-RUST-GUIDELINES.md`
- [x] All public items have `///` documentation
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] Feature-gated code compiles with and without its feature
- [x] No `.unwrap()`, `.expect()`, or panics in library code

Closes #7
