### PR TITLE
M4 #14: Define SwapPool trait

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -18,7 +18,8 @@ pub use crate::domain::{
 };
 
 // Re-export core traits
-// pub use crate::traits::{FromConfig, LiquidityPool, SwapPool};
+pub use crate::traits::SwapPool;
+// pub use crate::traits::{FromConfig, LiquidityPool};
 
 // Re-export math utilities
 pub use crate::math::CheckedArithmetic;

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -1,6 +1,10 @@
 //! Core trait abstractions for AMM pool operations.
 //!
 //! This module defines the primary traits that all pool implementations
-//! must satisfy: `SwapPool` for executing swaps, `LiquidityPool`
+//! must satisfy: [`SwapPool`] for executing swaps, `LiquidityPool`
 //! for managing positions, and `FromConfig` for configuration-driven
 //! pool construction.
+
+mod swap_pool;
+
+pub use swap_pool::SwapPool;

--- a/src/traits/swap_pool.rs
+++ b/src/traits/swap_pool.rs
@@ -1,0 +1,114 @@
+//! Core swap pool trait for executing swaps and querying pool state.
+//!
+//! [`SwapPool`] is the foundational abstraction that every AMM pool must
+//! implement.  It provides four methods covering the full lifecycle of a
+//! swap operation:
+//!
+//! 1. **Execute** — [`SwapPool::swap`] performs the actual token exchange.
+//! 2. **Quote** — [`SwapPool::spot_price`] returns the current exchange
+//!    rate between two tokens.
+//! 3. **Inspect pair** — [`SwapPool::token_pair`] returns the ordered
+//!    token pair managed by the pool.
+//! 4. **Inspect fees** — [`SwapPool::fee_tier`] returns the pool's fee
+//!    tier.
+//!
+//! # Fee Deduction Invariant
+//!
+//! All swap implementations **must** deduct fees from the input amount
+//! before applying the pricing formula:
+//!
+//! ```text
+//! fee_amount = amount_in × fee_bps / 10_000
+//! net_input  = amount_in − fee_amount
+//! amount_out = price_curve(net_input)
+//! ```
+//!
+//! # Dispatch Model
+//!
+//! Pools are dispatched via enums (not `dyn` trait objects), enabling
+//! static polymorphism and `no_std` compatibility.  See the `pools`
+//! module for the `PoolBox` enum that wraps all pool variants.
+
+use crate::domain::{FeeTier, Price, SwapResult, SwapSpec, Token, TokenPair};
+use crate::error::AmmError;
+
+/// Core trait for all AMM liquidity pools.
+///
+/// Every pool implementation must provide all four methods — there are no
+/// default implementations.  This ensures that each pool type explicitly
+/// handles swap execution, price calculation, and state queries.
+///
+/// # Implementors
+///
+/// Concrete implementations include:
+///
+/// - `ConstantProductPool` — Uniswap v2 style (`x · y = k`)
+/// - `ConcentratedLiquidityPool` — Uniswap v3 style (tick-based)
+/// - `HybridPool` — Curve-style StableSwap
+/// - `WeightedPool` — Balancer-style weighted pools
+/// - `DynamicPool` — DODO-style proactive market making
+/// - `OrderBookPool` — Phoenix-style order book hybrid
+///
+/// # Errors
+///
+/// Methods that can fail return [`Result<T, AmmError>`].  Common error
+/// variants include:
+///
+/// - [`AmmError::InsufficientLiquidity`] — reserves too low for the swap
+/// - [`AmmError::ZeroReserve`] — one or both reserves are zero
+/// - [`AmmError::InvalidToken`] — input token is not part of the pool pair
+/// - [`AmmError::Overflow`] — arithmetic overflow during calculation
+pub trait SwapPool {
+    /// Executes a token swap on the pool.
+    ///
+    /// Fee is always deducted from the input amount **before** the pricing
+    /// formula is applied.  Reserve updates are atomic — partial fills are
+    /// forbidden; the swap either completes fully or returns an error.
+    ///
+    /// # Arguments
+    ///
+    /// - `spec` — the swap specification (exact-in or exact-out with amount).
+    /// - `token_in` — the token being sold; the pool determines the output
+    ///   token from its [`TokenPair`].
+    ///
+    /// # Errors
+    ///
+    /// - [`AmmError::InvalidToken`] if `token_in` is not part of the pool's
+    ///   token pair.
+    /// - [`AmmError::InsufficientLiquidity`] if pool reserves cannot satisfy
+    ///   the swap.
+    /// - [`AmmError::Overflow`] if any intermediate arithmetic overflows.
+    fn swap(&mut self, spec: SwapSpec, token_in: Token) -> Result<SwapResult, AmmError>;
+
+    /// Returns the current spot price between two tokens.
+    ///
+    /// The price is expressed as *units of `quote` per unit of `base`*.
+    /// Both `base` and `quote` must be members of the pool's
+    /// [`TokenPair`].
+    ///
+    /// # Arguments
+    ///
+    /// - `base` — the base token (denominator of the price ratio).
+    /// - `quote` — the quote token (numerator of the price ratio).
+    ///
+    /// # Errors
+    ///
+    /// - [`AmmError::InvalidToken`] if either token is not part of the
+    ///   pool's pair.
+    /// - [`AmmError::ZeroReserve`] if either reserve is zero.
+    fn spot_price(&self, base: &Token, quote: &Token) -> Result<Price, AmmError>;
+
+    /// Returns the ordered token pair managed by this pool.
+    ///
+    /// The pair is canonically ordered: `first().address() < second().address()`.
+    /// The ordering is immutable for the lifetime of the pool.
+    #[must_use]
+    fn token_pair(&self) -> &TokenPair;
+
+    /// Returns the fee tier applied to swaps.
+    ///
+    /// The fee tier is constant for the lifetime of the pool.  It is used
+    /// to calculate the fee deduction: `fee = amount_in × bps / 10_000`.
+    #[must_use]
+    fn fee_tier(&self) -> FeeTier;
+}


### PR DESCRIPTION
## Summary

Define the `SwapPool` trait — the core interface that every AMM pool implementation must satisfy for executing swaps and querying pool state.

## Changes

- **src/traits/swap_pool.rs**: New `SwapPool` trait with four methods:
  - `swap(&mut self, spec: SwapSpec, token_in: Token) -> Result<SwapResult, AmmError>` — executes a token swap with atomic reserve updates
  - `spot_price(&self, base: &Token, quote: &Token) -> Result<Price, AmmError>` — returns directional exchange rate
  - `token_pair(&self) -> &TokenPair` — returns the canonically-ordered token pair
  - `fee_tier(&self) -> FeeTier` — returns the pool's immutable fee tier
- **src/traits/mod.rs**: Added `swap_pool` submodule and `SwapPool` re-export
- **src/prelude.rs**: Added `SwapPool` re-export

## Technical Decisions

- **No default implementations**: All four methods are required — concrete pools must provide every implementation explicitly. This prevents accidental reliance on placeholder behavior.
- **`swap` takes `SwapSpec` and `Token` by value**: Both types are `Copy`, making by-value passing idiomatic and zero-cost.
- **`spot_price` takes base/quote by reference**: Allows querying the price in either direction without the caller needing to know the canonical ordering. Implementations validate that both tokens belong to the pool's pair.
- **`token_pair` returns `&TokenPair`**: Borrowed from the implementor, avoiding unnecessary copies for pools that store the pair inline.
- **`fee_tier` returns `FeeTier` by value**: `FeeTier` is `Copy` and small (wraps `BasisPoints`).
- **Fee deduction invariant documented**: Module-level docs specify that fees are always subtracted from input before the pricing formula: `net_input = amount_in - fee_amount`.
- **`#[must_use]` on accessor methods**: `token_pair` and `fee_tier` are marked `#[must_use]`. `swap` and `spot_price` return `Result` which is already `#[must_use]`.
- **Error contract documented**: Each method documents which `AmmError` variants it may return (`InvalidToken`, `InsufficientLiquidity`, `ZeroReserve`, `Overflow`).

## Testing

- [x] Unit tests — N/A (trait definition only, no logic to test)
- [x] Doc-tests — implicit via module compilation
- [x] Manual testing performed (`make lint-fix` + `make pre-push` — all 354 tests + 24 doc-tests passed, zero warnings)

## Checklist

- [x] Code follows `.internalDoc/09-RUST-GUIDELINES.md`
- [x] All public items have `///` documentation
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] Feature-gated code compiles with and without its feature
- [x] No `.unwrap()`, `.expect()`, or panics in library code

Closes #14