### PR TITLE
M4 #15: Define LiquidityPool trait

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -18,8 +18,8 @@ pub use crate::domain::{
 };
 
 // Re-export core traits
-pub use crate::traits::SwapPool;
-// pub use crate::traits::{FromConfig, LiquidityPool};
+pub use crate::traits::{LiquidityPool, SwapPool};
+// pub use crate::traits::FromConfig;
 
 // Re-export math utilities
 pub use crate::math::CheckedArithmetic;

--- a/src/traits/liquidity_pool.rs
+++ b/src/traits/liquidity_pool.rs
@@ -1,0 +1,140 @@
+//! Liquidity management trait extending [`SwapPool`].
+//!
+//! [`LiquidityPool`] adds position management and fee collection on top
+//! of the core swap functionality provided by [`SwapPool`].  Every pool
+//! that supports liquidity provision must implement this trait.
+//!
+//! # Liquidity Accounting Invariant
+//!
+//! The total liquidity reported by [`LiquidityPool::total_liquidity`]
+//! **only** changes through [`LiquidityPool::add_liquidity`] and
+//! [`LiquidityPool::remove_liquidity`].  No other operation (swaps,
+//! fee collection, price queries) may alter the total.
+//!
+//! For a pool with `n` positions and total liquidity `L`:
+//!
+//! ```text
+//! L = Σ position[i].liquidity   for all i
+//! ```
+//!
+//! # Fee Collection Isolation
+//!
+//! Fee collection via [`LiquidityPool::collect_fees`] returns accrued
+//! fees **without** altering pool reserves or the price curve.  Fees
+//! accumulate per-position during swaps and are claimed explicitly.
+//!
+//! Calling `collect_fees` twice on the same position without
+//! intermediate swaps returns zero the second time (idempotent).
+
+use super::SwapPool;
+use crate::domain::{Amount, Liquidity, LiquidityChange, Position};
+use crate::error::AmmError;
+
+/// Trait for pools that support liquidity provision and fee collection.
+///
+/// Extends [`SwapPool`] with methods to add/remove liquidity, query
+/// total liquidity, and collect accrued trading fees.
+///
+/// # Implementors
+///
+/// All six pool types implement this trait:
+///
+/// - `ConstantProductPool` — uniform liquidity across full price range
+/// - `ConcentratedLiquidityPool` — liquidity concentrated in tick ranges
+/// - `HybridPool` — StableSwap with amplification factor
+/// - `WeightedPool` — multi-weight liquidity provision
+/// - `DynamicPool` — PMM-managed liquidity
+/// - `OrderBookPool` — order book hybrid with maker liquidity
+///
+/// # Errors
+///
+/// Methods that can fail return [`Result<T, AmmError>`].  Common error
+/// variants include:
+///
+/// - [`AmmError::InsufficientLiquidity`] — removing more than available
+/// - [`AmmError::InvalidLiquidity`] — invalid liquidity parameters
+/// - [`AmmError::PositionNotFound`] — position does not exist
+/// - [`AmmError::Overflow`] — arithmetic overflow during calculation
+pub trait LiquidityPool: SwapPool {
+    /// Adds liquidity to the pool.
+    ///
+    /// The `change` parameter describes the tokens to deposit.  The pool
+    /// computes the liquidity minted based on current reserves and the
+    /// deposited amounts.
+    ///
+    /// # Arguments
+    ///
+    /// - `change` — an [`LiquidityChange::Add`] variant specifying the
+    ///   amounts of token A and token B to deposit.
+    ///
+    /// # Returns
+    ///
+    /// The [`Amount`] of liquidity units minted for the deposited tokens.
+    ///
+    /// # Errors
+    ///
+    /// - [`AmmError::InvalidQuantity`] if both deposit amounts are zero.
+    /// - [`AmmError::InvalidLiquidity`] if the change variant is not `Add`.
+    /// - [`AmmError::Overflow`] if any intermediate arithmetic overflows.
+    fn add_liquidity(&mut self, change: &LiquidityChange) -> Result<Amount, AmmError>;
+
+    /// Removes liquidity from the pool.
+    ///
+    /// The `change` parameter specifies how much liquidity to withdraw.
+    /// The pool computes the token amounts returned proportionally to
+    /// the position's share of total liquidity.
+    ///
+    /// # Arguments
+    ///
+    /// - `change` — a [`LiquidityChange::Remove`] variant specifying the
+    ///   amount of liquidity to withdraw.
+    ///
+    /// # Returns
+    ///
+    /// The [`Amount`] of tokens returned (combined value).
+    ///
+    /// # Errors
+    ///
+    /// - [`AmmError::InsufficientLiquidity`] if the requested amount
+    ///   exceeds the position's balance.
+    /// - [`AmmError::InvalidLiquidity`] if the change variant is not
+    ///   `Remove` or liquidity is zero.
+    /// - [`AmmError::Overflow`] if any intermediate arithmetic overflows.
+    fn remove_liquidity(&mut self, change: &LiquidityChange) -> Result<Amount, AmmError>;
+
+    /// Collects accrued trading fees for a position.
+    ///
+    /// Returns the total fees accumulated by the position since the last
+    /// collection.  After collection, the position's fee counters are
+    /// reset to zero.  Pool reserves and the price curve are **not**
+    /// affected.
+    ///
+    /// # Idempotency
+    ///
+    /// Calling this method twice on the same position without
+    /// intermediate swaps returns zero the second time.
+    ///
+    /// # Arguments
+    ///
+    /// - `position` — the position whose fees should be collected.
+    ///
+    /// # Returns
+    ///
+    /// The [`Amount`] of fees collected.
+    ///
+    /// # Errors
+    ///
+    /// - [`AmmError::PositionNotFound`] if the position does not exist
+    ///   in this pool.
+    fn collect_fees(&mut self, position: &Position) -> Result<Amount, AmmError>;
+
+    /// Returns the total active liquidity in the pool.
+    ///
+    /// This is the sum of all liquidity units across all active
+    /// positions.  It does not include withdrawn or inactive positions.
+    ///
+    /// Used for calculating an individual position's share:
+    /// `position_liquidity / total_liquidity`.
+    #[must_use]
+    fn total_liquidity(&self) -> Liquidity;
+}

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -1,10 +1,12 @@
 //! Core trait abstractions for AMM pool operations.
 //!
 //! This module defines the primary traits that all pool implementations
-//! must satisfy: [`SwapPool`] for executing swaps, `LiquidityPool`
+//! must satisfy: [`SwapPool`] for executing swaps, [`LiquidityPool`]
 //! for managing positions, and `FromConfig` for configuration-driven
 //! pool construction.
 
+mod liquidity_pool;
 mod swap_pool;
 
+pub use liquidity_pool::LiquidityPool;
 pub use swap_pool::SwapPool;


### PR DESCRIPTION
## Summary

Define the `LiquidityPool` trait — extends `SwapPool` with position management and fee collection capabilities.

## Changes

- **src/traits/liquidity_pool.rs**: New `LiquidityPool` trait with four methods:
  - `add_liquidity(&mut self, change: &LiquidityChange) -> Result<Amount, AmmError>` — deposits tokens, returns liquidity minted
  - `remove_liquidity(&mut self, change: &LiquidityChange) -> Result<Amount, AmmError>` — withdraws liquidity, returns tokens
  - `collect_fees(&mut self, position: &Position) -> Result<Amount, AmmError>` — claims accrued fees without altering reserves
  - `total_liquidity(&self) -> Liquidity` — sum of all active position liquidity
- **src/traits/mod.rs**: Added `liquidity_pool` submodule and `LiquidityPool` re-export
- **src/prelude.rs**: Added `LiquidityPool` re-export

## Technical Decisions

- **Supertrait `SwapPool`**: Every `LiquidityPool` is also a `SwapPool`. This enforces that any pool supporting liquidity provision must also support swaps, matching the spec hierarchy.
- **No default implementations**: All four methods are required — concrete pools must provide every implementation explicitly.
- **`&LiquidityChange` by reference**: `LiquidityChange` is `Copy`, but the issue specifies reference parameters. Using references is consistent with the issue's API contract and allows future non-Copy extensions without a breaking change.
- **`collect_fees` takes `&mut self`**: Fee collection resets per-position counters, which is a mutation. The spec's idempotency contract (second call returns zero without intermediate swaps) is documented.
- **`total_liquidity` returns `Liquidity` by value**: Infallible accessor, marked `#[must_use]`.
- **Liquidity accounting invariant documented**: Module-level docs specify that `total_liquidity` only changes through `add_liquidity` and `remove_liquidity`.
- **Fee collection isolation documented**: `collect_fees` does not alter pool reserves or the price curve.

## Testing

- [x] Unit tests — N/A (trait definition only, no logic to test)
- [x] Doc-tests — implicit via module compilation
- [x] Manual testing performed (`make lint-fix` + `make pre-push` — all 354 tests + 24 doc-tests passed, zero warnings)

## Checklist

- [x] Code follows `.internalDoc/09-RUST-GUIDELINES.md`
- [x] All public items have `///` documentation
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] Feature-gated code compiles with and without its feature
- [x] No `.unwrap()`, `.expect()`, or panics in library code

Closes #15