### PR TITLE
M4 #16: Define FromConfig trait

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -18,8 +18,7 @@ pub use crate::domain::{
 };
 
 // Re-export core traits
-pub use crate::traits::{LiquidityPool, SwapPool};
-// pub use crate::traits::FromConfig;
+pub use crate::traits::{FromConfig, LiquidityPool, SwapPool};
 
 // Re-export math utilities
 pub use crate::math::CheckedArithmetic;

--- a/src/traits/from_config.rs
+++ b/src/traits/from_config.rs
@@ -1,0 +1,83 @@
+//! Generic construction trait for pool instantiation from configuration.
+//!
+//! [`FromConfig`] provides a uniform interface for creating pool instances
+//! from their respective configuration structs.  Each pool type implements
+//! `FromConfig<C>` for its own config variant, enabling the factory to
+//! dispatch construction without `dyn` trait objects.
+//!
+//! # Validation Contract
+//!
+//! Implementations **must** validate all configuration invariants during
+//! construction.  A successfully constructed pool is guaranteed to be in
+//! a valid initial state.  Common validations include:
+//!
+//! - Token pair has two distinct addresses
+//! - Fee tier is within supported range
+//! - Initial reserves are non-zero (where applicable)
+//! - Pool-specific parameters are valid (e.g., tick spacing > 0 for CLMM,
+//!   weights sum to 100% for weighted pools)
+//!
+//! # Factory Integration
+//!
+//! The [`DefaultPoolFactory`](crate::factory) uses `FromConfig` to
+//! construct pools from [`AmmConfig`](crate::config) variants:
+//!
+//! ```text
+//! AmmConfig::ConstantProduct(cfg) => ConstantProductPool::from_config(&cfg)
+//! AmmConfig::Clmm(cfg)            => ConcentratedLiquidityPool::from_config(&cfg)
+//! ```
+//!
+//! # No Generic Blanket Implementation
+//!
+//! There is no `impl<T> FromConfig<T>` blanket — each pool must
+//! explicitly implement the trait for its specific config type.  This
+//! ensures that every pool-config pairing is intentional and that
+//! validation logic is pool-specific.
+
+use crate::error::AmmError;
+
+/// Generic construction trait for building a pool from a configuration.
+///
+/// Each pool type implements this trait for its own configuration struct,
+/// enabling type-safe construction with full validation.
+///
+/// # Type Parameters
+///
+/// - `C` — the configuration type that fully describes the pool's
+///   immutable parameters (token pair, fee tier, initial reserves, etc.).
+///
+/// # Implementors
+///
+/// - `impl FromConfig<ConstantProductConfig> for ConstantProductPool`
+/// - `impl FromConfig<ClmmConfig> for ConcentratedLiquidityPool`
+/// - `impl FromConfig<HybridConfig> for HybridPool`
+/// - `impl FromConfig<WeightedConfig> for WeightedPool`
+/// - `impl FromConfig<DynamicConfig> for DynamicPool`
+/// - `impl FromConfig<OrderBookConfig> for OrderBookPool`
+///
+/// # Errors
+///
+/// Returns [`AmmError::InvalidConfiguration`] (or a more specific
+/// variant) if the configuration is invalid.
+pub trait FromConfig<C> {
+    /// Creates a new pool instance from the given configuration.
+    ///
+    /// The implementation validates all configuration invariants and
+    /// returns a fully initialized pool on success.  The configuration
+    /// is taken by reference because it may be reused (e.g., for logging
+    /// or retry).
+    ///
+    /// # Arguments
+    ///
+    /// - `config` — immutable reference to the pool configuration.
+    ///
+    /// # Errors
+    ///
+    /// - [`AmmError::InvalidConfiguration`] if any pool parameter is
+    ///   out of range or inconsistent.
+    /// - [`AmmError::InvalidToken`] if the token pair is invalid.
+    /// - [`AmmError::InvalidFee`] if the fee tier is unsupported.
+    fn from_config(config: &C) -> Result<Self, AmmError>
+    where
+        Self: Sized;
+}

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -2,11 +2,13 @@
 //!
 //! This module defines the primary traits that all pool implementations
 //! must satisfy: [`SwapPool`] for executing swaps, [`LiquidityPool`]
-//! for managing positions, and `FromConfig` for configuration-driven
+//! for managing positions, and [`FromConfig`] for configuration-driven
 //! pool construction.
 
+mod from_config;
 mod liquidity_pool;
 mod swap_pool;
 
+pub use from_config::FromConfig;
 pub use liquidity_pool::LiquidityPool;
 pub use swap_pool::SwapPool;


### PR DESCRIPTION
## Summary

Define the `FromConfig<C>` trait — a generic construction interface for building pool instances from their respective configuration structs.

## Changes

- **src/traits/from_config.rs**: New `FromConfig<C>` trait with a single method:
  - `from_config(config: &C) -> Result<Self, AmmError>` — creates a pool from configuration with full validation
- **src/traits/mod.rs**: Added `from_config` submodule and `FromConfig` re-export; linked `FromConfig` in module docs
- **src/prelude.rs**: Added `FromConfig` re-export

## Technical Decisions

- **Generic over `C`**: Each pool type implements `FromConfig` for its own config struct (e.g., `impl FromConfig<ConstantProductConfig> for ConstantProductPool`). No blanket `impl<T> FromConfig<T>` — every pool-config pairing must be explicit and intentional.
- **`config` by reference**: Configuration is taken by `&C` to allow reuse (e.g., logging, retry) without requiring `Clone`.
- **`where Self: Sized` bound**: Explicit on the method to allow the trait to be used without object safety constraints. Since the project uses enum dispatch (not `dyn`), this is consistent with the design.
- **Validation contract documented**: Module-level docs specify that implementations must validate all configuration invariants during construction (token pair validity, fee tier range, reserve bounds, pool-specific parameters).
- **Factory integration documented**: Shows how `DefaultPoolFactory` will use `FromConfig` to dispatch construction from `AmmConfig` variants.
- **Error variants documented**: `InvalidConfiguration`, `InvalidToken`, `InvalidFee`.

## Testing

- [x] Unit tests — N/A (trait definition only, no logic to test)
- [x] Doc-tests — implicit via module compilation
- [x] Manual testing performed (`make lint-fix` + `make pre-push` — all 354 tests + 24 doc-tests passed, zero warnings)

## Checklist

- [x] Code follows `.internalDoc/09-RUST-GUIDELINES.md`
- [x] All public items have `///` documentation
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] Feature-gated code compiles with and without its feature
- [x] No `.unwrap()`, `.expect()`, or panics in library code

Closes #16