### PR TITLE
M5 #17: Define AmmConfig enum with 6 variants

### DIFF
--- a/src/config/amm_config.rs
+++ b/src/config/amm_config.rs
@@ -1,0 +1,270 @@
+//! Top-level AMM configuration enum.
+//!
+//! [`AmmConfig`] is the declarative blueprint for creating any pool type.
+//! Each variant wraps a pool-specific configuration struct that fully
+//! describes the pool's immutable parameters.
+//!
+//! # Factory Integration
+//!
+//! The factory pattern matches on `AmmConfig` to dispatch construction:
+//!
+//! ```text
+//! match config {
+//!     AmmConfig::ConstantProduct(cfg) => ConstantProductPool::from_config(&cfg),
+//!     AmmConfig::Clmm(cfg)            => ConcentratedLiquidityPool::from_config(&cfg),
+//!     ...
+//! }
+//! ```
+
+use super::{
+    ClmmConfig, ConstantProductConfig, DynamicConfig, HybridConfig, OrderBookConfig, WeightedConfig,
+};
+use crate::error::AmmError;
+
+/// Top-level configuration enum for all AMM pool types.
+///
+/// Each variant wraps its pool-specific configuration struct.  The enum
+/// is used by the factory to determine which pool type to construct and
+/// with what parameters.
+///
+/// # Variants
+///
+/// - [`ConstantProduct`](AmmConfig::ConstantProduct) — Uniswap V2 style (`x · y = k`)
+/// - [`Clmm`](AmmConfig::Clmm) — Uniswap V3 style (concentrated liquidity)
+/// - [`Hybrid`](AmmConfig::Hybrid) — Curve-style StableSwap
+/// - [`Weighted`](AmmConfig::Weighted) — Balancer-style weighted pools
+/// - [`Dynamic`](AmmConfig::Dynamic) — DODO-style proactive market making
+/// - [`OrderBook`](AmmConfig::OrderBook) — Phoenix-style order book hybrid
+///
+/// # Validation
+///
+/// Call [`validate()`](AmmConfig::validate) to check all configuration
+/// invariants before constructing a pool.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AmmConfig {
+    /// Constant Product AMM configuration (Uniswap V2 style).
+    ConstantProduct(ConstantProductConfig),
+    /// Concentrated Liquidity Market Maker configuration (Uniswap V3 style).
+    Clmm(ClmmConfig),
+    /// Hybrid / StableSwap configuration (Curve style).
+    Hybrid(HybridConfig),
+    /// Weighted pool configuration (Balancer style).
+    Weighted(WeightedConfig),
+    /// Dynamic / Proactive Market Maker configuration (DODO style).
+    Dynamic(DynamicConfig),
+    /// Order Book hybrid configuration (Phoenix style).
+    OrderBook(OrderBookConfig),
+}
+
+impl AmmConfig {
+    /// Validates the inner configuration by delegating to the
+    /// variant-specific `validate()` method.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same [`AmmError`] that the inner config's
+    /// `validate()` would return.
+    pub fn validate(&self) -> Result<(), AmmError> {
+        match self {
+            Self::ConstantProduct(cfg) => cfg.validate(),
+            Self::Clmm(cfg) => cfg.validate(),
+            Self::Hybrid(cfg) => cfg.validate(),
+            Self::Weighted(cfg) => cfg.validate(),
+            Self::Dynamic(cfg) => cfg.validate(),
+            Self::OrderBook(cfg) => cfg.validate(),
+        }
+    }
+
+    /// Returns `true` if this is a [`ConstantProduct`](Self::ConstantProduct) variant.
+    #[must_use]
+    pub const fn is_constant_product(&self) -> bool {
+        matches!(self, Self::ConstantProduct(_))
+    }
+
+    /// Returns `true` if this is a [`Clmm`](Self::Clmm) variant.
+    #[must_use]
+    pub const fn is_clmm(&self) -> bool {
+        matches!(self, Self::Clmm(_))
+    }
+
+    /// Returns `true` if this is a [`Hybrid`](Self::Hybrid) variant.
+    #[must_use]
+    pub const fn is_hybrid(&self) -> bool {
+        matches!(self, Self::Hybrid(_))
+    }
+
+    /// Returns `true` if this is a [`Weighted`](Self::Weighted) variant.
+    #[must_use]
+    pub const fn is_weighted(&self) -> bool {
+        matches!(self, Self::Weighted(_))
+    }
+
+    /// Returns `true` if this is a [`Dynamic`](Self::Dynamic) variant.
+    #[must_use]
+    pub const fn is_dynamic(&self) -> bool {
+        matches!(self, Self::Dynamic(_))
+    }
+
+    /// Returns `true` if this is an [`OrderBook`](Self::OrderBook) variant.
+    #[must_use]
+    pub const fn is_order_book(&self) -> bool {
+        matches!(self, Self::OrderBook(_))
+    }
+}
+
+impl core::fmt::Display for AmmConfig {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::ConstantProduct(_) => write!(f, "ConstantProduct"),
+            Self::Clmm(_) => write!(f, "Clmm"),
+            Self::Hybrid(_) => write!(f, "Hybrid"),
+            Self::Weighted(_) => write!(f, "Weighted"),
+            Self::Dynamic(_) => write!(f, "Dynamic"),
+            Self::OrderBook(_) => write!(f, "OrderBook"),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic)]
+mod tests {
+    use super::*;
+    use crate::domain::{
+        Amount, BasisPoints, Decimals, FeeTier, Price, Tick, Token, TokenAddress, TokenPair,
+    };
+
+    fn make_pair() -> TokenPair {
+        let Ok(d6) = Decimals::new(6) else {
+            panic!("valid decimals");
+        };
+        let Ok(d18) = Decimals::new(18) else {
+            panic!("valid decimals");
+        };
+        let tok_a = Token::new(TokenAddress::from_bytes([1u8; 32]), d6);
+        let tok_b = Token::new(TokenAddress::from_bytes([2u8; 32]), d18);
+        let Ok(pair) = TokenPair::new(tok_a, tok_b) else {
+            panic!("expected valid pair");
+        };
+        pair
+    }
+
+    fn fee() -> FeeTier {
+        FeeTier::new(BasisPoints::new(30))
+    }
+
+    fn tick(v: i32) -> Tick {
+        let Ok(t) = Tick::new(v) else {
+            panic!("valid tick expected");
+        };
+        t
+    }
+
+    #[test]
+    fn constant_product_variant() {
+        let Ok(cfg) =
+            ConstantProductConfig::new(make_pair(), fee(), Amount::new(1_000), Amount::new(2_000))
+        else {
+            panic!("expected Ok");
+        };
+        let amm = AmmConfig::ConstantProduct(cfg);
+        assert!(amm.is_constant_product());
+        assert!(!amm.is_clmm());
+        assert!(amm.validate().is_ok());
+    }
+
+    #[test]
+    fn clmm_variant() {
+        let Ok(cfg) = ClmmConfig::new(make_pair(), fee(), 10, tick(0), vec![]) else {
+            panic!("expected Ok");
+        };
+        let amm = AmmConfig::Clmm(cfg);
+        assert!(amm.is_clmm());
+        assert!(amm.validate().is_ok());
+    }
+
+    #[test]
+    fn hybrid_variant() {
+        let Ok(cfg) = HybridConfig::new(
+            make_pair(),
+            fee(),
+            100,
+            Amount::new(1_000),
+            Amount::new(1_000),
+        ) else {
+            panic!("expected Ok");
+        };
+        let amm = AmmConfig::Hybrid(cfg);
+        assert!(amm.is_hybrid());
+        assert!(amm.validate().is_ok());
+    }
+
+    #[test]
+    fn weighted_variant() {
+        let bps = |v: u32| -> BasisPoints { BasisPoints::new(v) };
+        let tok = |byte: u8| -> Token {
+            let Ok(d) = Decimals::new(6) else {
+                panic!("valid decimals");
+            };
+            Token::new(TokenAddress::from_bytes([byte; 32]), d)
+        };
+        let Ok(cfg) = WeightedConfig::new(
+            vec![tok(1), tok(2)],
+            vec![bps(5_000), bps(5_000)],
+            fee(),
+            vec![Amount::new(100), Amount::new(200)],
+        ) else {
+            panic!("expected Ok");
+        };
+        let amm = AmmConfig::Weighted(cfg);
+        assert!(amm.is_weighted());
+        assert!(amm.validate().is_ok());
+    }
+
+    #[test]
+    fn dynamic_variant() {
+        let Ok(price) = Price::new(100.0) else {
+            panic!("expected valid price");
+        };
+        let Ok(cfg) = DynamicConfig::new(
+            make_pair(),
+            fee(),
+            price,
+            0.5,
+            Amount::new(1_000),
+            Amount::new(100_000),
+        ) else {
+            panic!("expected Ok");
+        };
+        let amm = AmmConfig::Dynamic(cfg);
+        assert!(amm.is_dynamic());
+        assert!(amm.validate().is_ok());
+    }
+
+    #[test]
+    fn order_book_variant() {
+        let Ok(cfg) = OrderBookConfig::new(make_pair(), fee(), Amount::new(1), Amount::new(10))
+        else {
+            panic!("expected Ok");
+        };
+        let amm = AmmConfig::OrderBook(cfg);
+        assert!(amm.is_order_book());
+        assert!(amm.validate().is_ok());
+    }
+
+    #[test]
+    fn display_variants() {
+        let Ok(cp) = ConstantProductConfig::new(make_pair(), fee(), Amount::new(1), Amount::new(1))
+        else {
+            panic!("expected Ok");
+        };
+        assert_eq!(
+            format!("{}", AmmConfig::ConstantProduct(cp)),
+            "ConstantProduct"
+        );
+
+        let Ok(clmm) = ClmmConfig::new(make_pair(), fee(), 1, tick(0), vec![]) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(format!("{}", AmmConfig::Clmm(clmm)), "Clmm");
+    }
+}

--- a/src/config/clmm.rs
+++ b/src/config/clmm.rs
@@ -1,0 +1,174 @@
+//! Configuration for Concentrated Liquidity Market Maker pools (Uniswap V3 style).
+
+use crate::domain::{FeeTier, Position, Tick, TokenPair};
+use crate::error::AmmError;
+
+/// Configuration for a Concentrated Liquidity Market Maker (CLMM) pool.
+///
+/// Defines the immutable parameters for a Uniswap V3 style pool where
+/// liquidity providers concentrate their capital within specific tick
+/// (price) ranges.
+///
+/// # Key Relationships
+///
+/// - Price at tick `i`: `P(i) = 1.0001^i`
+/// - Liquidity `L` relates to reserves: `L = √(x × y)`
+///
+/// # Validation
+///
+/// - `tick_spacing` must be greater than zero.
+/// - `current_tick` must be within the valid tick range.
+/// - Each position must have `lower_tick < upper_tick` (enforced by
+///   [`Position`] construction).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ClmmConfig {
+    token_pair: TokenPair,
+    fee_tier: FeeTier,
+    tick_spacing: u32,
+    current_tick: Tick,
+    positions: Vec<Position>,
+}
+
+impl ClmmConfig {
+    /// Creates a new `ClmmConfig`.
+    ///
+    /// # Arguments
+    ///
+    /// - `tick_spacing` — granularity of tick positions (standard values:
+    ///   1, 10, 60, 200). Must be greater than zero.
+    /// - `current_tick` — the active tick at pool creation.
+    /// - `positions` — initial liquidity provider positions (may be empty).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AmmError::InvalidConfiguration`] if `tick_spacing` is zero.
+    pub fn new(
+        token_pair: TokenPair,
+        fee_tier: FeeTier,
+        tick_spacing: u32,
+        current_tick: Tick,
+        positions: Vec<Position>,
+    ) -> Result<Self, AmmError> {
+        let config = Self {
+            token_pair,
+            fee_tier,
+            tick_spacing,
+            current_tick,
+            positions,
+        };
+        config.validate()?;
+        Ok(config)
+    }
+
+    /// Validates all configuration invariants.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AmmError::InvalidConfiguration`] if `tick_spacing` is zero.
+    pub fn validate(&self) -> Result<(), AmmError> {
+        if self.tick_spacing == 0 {
+            return Err(AmmError::InvalidConfiguration(
+                "tick spacing must be greater than zero",
+            ));
+        }
+        Ok(())
+    }
+
+    /// Returns the token pair.
+    #[must_use]
+    pub const fn token_pair(&self) -> &TokenPair {
+        &self.token_pair
+    }
+
+    /// Returns the fee tier.
+    #[must_use]
+    pub const fn fee_tier(&self) -> FeeTier {
+        self.fee_tier
+    }
+
+    /// Returns the tick spacing.
+    #[must_use]
+    pub const fn tick_spacing(&self) -> u32 {
+        self.tick_spacing
+    }
+
+    /// Returns the current (initial) tick.
+    #[must_use]
+    pub const fn current_tick(&self) -> Tick {
+        self.current_tick
+    }
+
+    /// Returns a reference to the initial positions.
+    #[must_use]
+    pub fn positions(&self) -> &[Position] {
+        &self.positions
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic)]
+mod tests {
+    use super::*;
+    use crate::domain::{BasisPoints, Decimals, Liquidity, Token, TokenAddress};
+
+    fn make_pair() -> TokenPair {
+        let Ok(d6) = Decimals::new(6) else {
+            panic!("valid decimals");
+        };
+        let Ok(d18) = Decimals::new(18) else {
+            panic!("valid decimals");
+        };
+        let tok_a = Token::new(TokenAddress::from_bytes([1u8; 32]), d6);
+        let tok_b = Token::new(TokenAddress::from_bytes([2u8; 32]), d18);
+        let Ok(pair) = TokenPair::new(tok_a, tok_b) else {
+            panic!("expected valid pair");
+        };
+        pair
+    }
+
+    fn fee() -> FeeTier {
+        FeeTier::new(BasisPoints::new(30))
+    }
+
+    fn tick(v: i32) -> Tick {
+        let Ok(t) = Tick::new(v) else {
+            panic!("valid tick expected");
+        };
+        t
+    }
+
+    #[test]
+    fn valid_config_no_positions() {
+        let result = ClmmConfig::new(make_pair(), fee(), 10, tick(0), vec![]);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn valid_config_with_positions() {
+        let Ok(pos) = Position::new(tick(-100), tick(100), Liquidity::new(1_000)) else {
+            panic!("expected valid position");
+        };
+        let result = ClmmConfig::new(make_pair(), fee(), 10, tick(0), vec![pos]);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn zero_tick_spacing_rejected() {
+        let result = ClmmConfig::new(make_pair(), fee(), 0, tick(0), vec![]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn accessors() {
+        let pair = make_pair();
+        let f = fee();
+        let Ok(cfg) = ClmmConfig::new(pair, f, 60, tick(500), vec![]) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(*cfg.token_pair(), pair);
+        assert_eq!(cfg.fee_tier(), f);
+        assert_eq!(cfg.tick_spacing(), 60);
+        assert_eq!(cfg.current_tick(), tick(500));
+        assert!(cfg.positions().is_empty());
+    }
+}

--- a/src/config/constant_product.rs
+++ b/src/config/constant_product.rs
@@ -1,0 +1,147 @@
+//! Configuration for Constant Product AMM pools (Uniswap V2 style).
+
+use crate::domain::{Amount, FeeTier, TokenPair};
+use crate::error::AmmError;
+
+/// Configuration for a Constant Product AMM pool (`x · y = k`).
+///
+/// Defines the immutable parameters for a Uniswap V2 style pool:
+/// token pair, fee tier, and initial reserves.
+///
+/// # Derived Values
+///
+/// - Initial invariant: `k = reserve_a × reserve_b`
+/// - Initial price (token A in terms of token B): `P₀ = reserve_b / reserve_a`
+///
+/// # Validation
+///
+/// - Both reserves must be non-zero.
+/// - The token pair is validated at [`TokenPair`] construction time.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConstantProductConfig {
+    token_pair: TokenPair,
+    fee_tier: FeeTier,
+    reserve_a: Amount,
+    reserve_b: Amount,
+}
+
+impl ConstantProductConfig {
+    /// Creates a new `ConstantProductConfig`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AmmError::ZeroReserve`] if either reserve is zero.
+    pub fn new(
+        token_pair: TokenPair,
+        fee_tier: FeeTier,
+        reserve_a: Amount,
+        reserve_b: Amount,
+    ) -> Result<Self, AmmError> {
+        let config = Self {
+            token_pair,
+            fee_tier,
+            reserve_a,
+            reserve_b,
+        };
+        config.validate()?;
+        Ok(config)
+    }
+
+    /// Validates all configuration invariants.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AmmError::ZeroReserve`] if either reserve is zero.
+    pub fn validate(&self) -> Result<(), AmmError> {
+        if self.reserve_a.is_zero() {
+            return Err(AmmError::ZeroReserve);
+        }
+        if self.reserve_b.is_zero() {
+            return Err(AmmError::ZeroReserve);
+        }
+        Ok(())
+    }
+
+    /// Returns the token pair.
+    #[must_use]
+    pub const fn token_pair(&self) -> &TokenPair {
+        &self.token_pair
+    }
+
+    /// Returns the fee tier.
+    #[must_use]
+    pub const fn fee_tier(&self) -> FeeTier {
+        self.fee_tier
+    }
+
+    /// Returns the initial reserve of token A.
+    pub const fn reserve_a(&self) -> Amount {
+        self.reserve_a
+    }
+
+    /// Returns the initial reserve of token B.
+    pub const fn reserve_b(&self) -> Amount {
+        self.reserve_b
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic)]
+mod tests {
+    use super::*;
+    use crate::domain::{BasisPoints, Decimals, Token, TokenAddress};
+
+    fn make_pair() -> TokenPair {
+        let Ok(d6) = Decimals::new(6) else {
+            panic!("valid decimals");
+        };
+        let Ok(d18) = Decimals::new(18) else {
+            panic!("valid decimals");
+        };
+        let tok_a = Token::new(TokenAddress::from_bytes([1u8; 32]), d6);
+        let tok_b = Token::new(TokenAddress::from_bytes([2u8; 32]), d18);
+        let Ok(pair) = TokenPair::new(tok_a, tok_b) else {
+            panic!("expected valid pair");
+        };
+        pair
+    }
+
+    fn fee() -> FeeTier {
+        FeeTier::new(BasisPoints::new(30))
+    }
+
+    #[test]
+    fn valid_config() {
+        let result =
+            ConstantProductConfig::new(make_pair(), fee(), Amount::new(1_000), Amount::new(2_000));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn zero_reserve_a_rejected() {
+        let result =
+            ConstantProductConfig::new(make_pair(), fee(), Amount::ZERO, Amount::new(1_000));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn zero_reserve_b_rejected() {
+        let result =
+            ConstantProductConfig::new(make_pair(), fee(), Amount::new(1_000), Amount::ZERO);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn accessors() {
+        let pair = make_pair();
+        let f = fee();
+        let Ok(cfg) = ConstantProductConfig::new(pair, f, Amount::new(100), Amount::new(200))
+        else {
+            panic!("expected Ok");
+        };
+        assert_eq!(*cfg.token_pair(), pair);
+        assert_eq!(cfg.fee_tier(), f);
+        assert_eq!(cfg.reserve_a(), Amount::new(100));
+        assert_eq!(cfg.reserve_b(), Amount::new(200));
+    }
+}

--- a/src/config/dynamic.rs
+++ b/src/config/dynamic.rs
@@ -1,0 +1,287 @@
+//! Configuration for Dynamic / Proactive Market Maker pools (DODO style).
+
+use crate::domain::{Amount, FeeTier, Price, TokenPair};
+use crate::error::AmmError;
+
+/// Configuration for a Dynamic (Proactive Market Maker) pool.
+///
+/// Defines the immutable parameters for a DODO-style pool that uses an
+/// external price oracle to concentrate liquidity around the market price.
+///
+/// # Slippage Coefficient
+///
+/// The `slippage_coefficient` (`k`) controls liquidity concentration:
+///
+/// - `k = 0.0` — infinite liquidity at oracle price (effectively a taker)
+/// - `k = 1.0` — behaves like constant product
+/// - Typical values: 0.1–0.5
+///
+/// # Validation
+///
+/// - `slippage_coefficient` must be in the range `[0.0, 1.0]` and finite.
+/// - Both reserves must be non-zero.
+/// - `oracle_price` must be positive (non-zero).
+#[derive(Debug, Clone, PartialEq)]
+pub struct DynamicConfig {
+    token_pair: TokenPair,
+    fee_tier: FeeTier,
+    oracle_price: Price,
+    slippage_coefficient: f64,
+    base_reserve: Amount,
+    quote_reserve: Amount,
+}
+
+impl DynamicConfig {
+    /// Creates a new `DynamicConfig`.
+    ///
+    /// # Arguments
+    ///
+    /// - `slippage_coefficient` — the `k` parameter in `[0.0, 1.0]`.
+    /// - `oracle_price` — reference mid-price from external oracle (must
+    ///   be positive).
+    ///
+    /// # Errors
+    ///
+    /// - [`AmmError::InvalidConfiguration`] if `slippage_coefficient` is
+    ///   outside `[0.0, 1.0]` or not finite.
+    /// - [`AmmError::InvalidConfiguration`] if `oracle_price` is zero.
+    /// - [`AmmError::ZeroReserve`] if either reserve is zero.
+    pub fn new(
+        token_pair: TokenPair,
+        fee_tier: FeeTier,
+        oracle_price: Price,
+        slippage_coefficient: f64,
+        base_reserve: Amount,
+        quote_reserve: Amount,
+    ) -> Result<Self, AmmError> {
+        let config = Self {
+            token_pair,
+            fee_tier,
+            oracle_price,
+            slippage_coefficient,
+            base_reserve,
+            quote_reserve,
+        };
+        config.validate()?;
+        Ok(config)
+    }
+
+    /// Validates all configuration invariants.
+    ///
+    /// # Errors
+    ///
+    /// - [`AmmError::InvalidConfiguration`] if `slippage_coefficient` is
+    ///   outside `[0.0, 1.0]` or not finite.
+    /// - [`AmmError::InvalidConfiguration`] if `oracle_price` is zero.
+    /// - [`AmmError::ZeroReserve`] if either reserve is zero.
+    pub fn validate(&self) -> Result<(), AmmError> {
+        if !self.slippage_coefficient.is_finite()
+            || self.slippage_coefficient < 0.0
+            || self.slippage_coefficient > 1.0
+        {
+            return Err(AmmError::InvalidConfiguration(
+                "slippage coefficient must be in [0.0, 1.0] and finite",
+            ));
+        }
+        if self.oracle_price.get() <= 0.0 {
+            return Err(AmmError::InvalidConfiguration(
+                "oracle price must be positive",
+            ));
+        }
+        if self.base_reserve.is_zero() {
+            return Err(AmmError::ZeroReserve);
+        }
+        if self.quote_reserve.is_zero() {
+            return Err(AmmError::ZeroReserve);
+        }
+        Ok(())
+    }
+
+    /// Returns the token pair.
+    #[must_use]
+    pub const fn token_pair(&self) -> &TokenPair {
+        &self.token_pair
+    }
+
+    /// Returns the fee tier.
+    #[must_use]
+    pub const fn fee_tier(&self) -> FeeTier {
+        self.fee_tier
+    }
+
+    /// Returns the oracle reference price.
+    #[must_use]
+    pub const fn oracle_price(&self) -> Price {
+        self.oracle_price
+    }
+
+    /// Returns the slippage coefficient (`k`), in the range `[0.0, 1.0]`.
+    #[must_use]
+    pub const fn slippage_coefficient(&self) -> f64 {
+        self.slippage_coefficient
+    }
+
+    /// Returns the initial base token reserve.
+    pub const fn base_reserve(&self) -> Amount {
+        self.base_reserve
+    }
+
+    /// Returns the initial quote token reserve.
+    pub const fn quote_reserve(&self) -> Amount {
+        self.quote_reserve
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic)]
+mod tests {
+    use super::*;
+    use crate::domain::{BasisPoints, Decimals, Token, TokenAddress};
+
+    fn make_pair() -> TokenPair {
+        let Ok(d6) = Decimals::new(6) else {
+            panic!("valid decimals");
+        };
+        let Ok(d18) = Decimals::new(18) else {
+            panic!("valid decimals");
+        };
+        let tok_a = Token::new(TokenAddress::from_bytes([1u8; 32]), d6);
+        let tok_b = Token::new(TokenAddress::from_bytes([2u8; 32]), d18);
+        let Ok(pair) = TokenPair::new(tok_a, tok_b) else {
+            panic!("expected valid pair");
+        };
+        pair
+    }
+
+    fn fee() -> FeeTier {
+        FeeTier::new(BasisPoints::new(30))
+    }
+
+    fn oracle() -> Price {
+        let Ok(p) = Price::new(100.0) else {
+            panic!("expected valid price");
+        };
+        p
+    }
+
+    #[test]
+    fn valid_config() {
+        let result = DynamicConfig::new(
+            make_pair(),
+            fee(),
+            oracle(),
+            0.5,
+            Amount::new(1_000),
+            Amount::new(100_000),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn k_zero_valid() {
+        let result = DynamicConfig::new(
+            make_pair(),
+            fee(),
+            oracle(),
+            0.0,
+            Amount::new(1_000),
+            Amount::new(1_000),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn k_one_valid() {
+        let result = DynamicConfig::new(
+            make_pair(),
+            fee(),
+            oracle(),
+            1.0,
+            Amount::new(1_000),
+            Amount::new(1_000),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn k_negative_rejected() {
+        let result = DynamicConfig::new(
+            make_pair(),
+            fee(),
+            oracle(),
+            -0.1,
+            Amount::new(1_000),
+            Amount::new(1_000),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn k_above_one_rejected() {
+        let result = DynamicConfig::new(
+            make_pair(),
+            fee(),
+            oracle(),
+            1.1,
+            Amount::new(1_000),
+            Amount::new(1_000),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn k_nan_rejected() {
+        let result = DynamicConfig::new(
+            make_pair(),
+            fee(),
+            oracle(),
+            f64::NAN,
+            Amount::new(1_000),
+            Amount::new(1_000),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn zero_base_reserve_rejected() {
+        let result = DynamicConfig::new(
+            make_pair(),
+            fee(),
+            oracle(),
+            0.5,
+            Amount::ZERO,
+            Amount::new(1_000),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn zero_quote_reserve_rejected() {
+        let result = DynamicConfig::new(
+            make_pair(),
+            fee(),
+            oracle(),
+            0.5,
+            Amount::new(1_000),
+            Amount::ZERO,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn accessors() {
+        let pair = make_pair();
+        let f = fee();
+        let p = oracle();
+        let Ok(cfg) = DynamicConfig::new(pair, f, p, 0.3, Amount::new(500), Amount::new(600))
+        else {
+            panic!("expected Ok");
+        };
+        assert_eq!(*cfg.token_pair(), pair);
+        assert_eq!(cfg.fee_tier(), f);
+        assert_eq!(cfg.oracle_price(), p);
+        assert!((cfg.slippage_coefficient() - 0.3).abs() < f64::EPSILON);
+        assert_eq!(cfg.base_reserve(), Amount::new(500));
+        assert_eq!(cfg.quote_reserve(), Amount::new(600));
+    }
+}

--- a/src/config/hybrid.rs
+++ b/src/config/hybrid.rs
@@ -1,0 +1,194 @@
+//! Configuration for Hybrid / StableSwap AMM pools (Curve style).
+
+use crate::domain::{Amount, FeeTier, TokenPair};
+use crate::error::AmmError;
+
+/// Configuration for a Hybrid (StableSwap) AMM pool.
+///
+/// Defines the immutable parameters for a Curve-style pool specialized
+/// in low-slippage swaps between similarly-priced assets (e.g., stablecoins).
+///
+/// # Amplification Parameter
+///
+/// The `amplification` parameter (`A`) controls the curve shape:
+///
+/// - `A = 1` — curve degrades to constant product (`x · y = k`)
+/// - `A → ∞` — curve approaches constant sum (`x + y = const`, 1:1 swaps)
+/// - Typical range for stablecoin pairs: 50–5000
+///
+/// # Invariant
+///
+/// The StableSwap invariant for `n = 2` tokens:
+///
+/// ```text
+/// A · 2 · (x + y) + D = A · D · 2 + D³ / (4xy)
+/// ```
+///
+/// # Validation
+///
+/// - Both reserves must be non-zero.
+/// - Amplification must be greater than zero.
+#[derive(Debug, Clone, PartialEq)]
+pub struct HybridConfig {
+    token_pair: TokenPair,
+    fee_tier: FeeTier,
+    amplification: u32,
+    reserve_a: Amount,
+    reserve_b: Amount,
+}
+
+impl HybridConfig {
+    /// Creates a new `HybridConfig`.
+    ///
+    /// # Arguments
+    ///
+    /// - `amplification` — the StableSwap amplification coefficient
+    ///   (must be > 0, typically 50–5000).
+    ///
+    /// # Errors
+    ///
+    /// - [`AmmError::InvalidConfiguration`] if `amplification` is zero.
+    /// - [`AmmError::ZeroReserve`] if either reserve is zero.
+    pub fn new(
+        token_pair: TokenPair,
+        fee_tier: FeeTier,
+        amplification: u32,
+        reserve_a: Amount,
+        reserve_b: Amount,
+    ) -> Result<Self, AmmError> {
+        let config = Self {
+            token_pair,
+            fee_tier,
+            amplification,
+            reserve_a,
+            reserve_b,
+        };
+        config.validate()?;
+        Ok(config)
+    }
+
+    /// Validates all configuration invariants.
+    ///
+    /// # Errors
+    ///
+    /// - [`AmmError::InvalidConfiguration`] if `amplification` is zero.
+    /// - [`AmmError::ZeroReserve`] if either reserve is zero.
+    pub fn validate(&self) -> Result<(), AmmError> {
+        if self.amplification == 0 {
+            return Err(AmmError::InvalidConfiguration(
+                "amplification must be greater than zero",
+            ));
+        }
+        if self.reserve_a.is_zero() {
+            return Err(AmmError::ZeroReserve);
+        }
+        if self.reserve_b.is_zero() {
+            return Err(AmmError::ZeroReserve);
+        }
+        Ok(())
+    }
+
+    /// Returns the token pair.
+    #[must_use]
+    pub const fn token_pair(&self) -> &TokenPair {
+        &self.token_pair
+    }
+
+    /// Returns the fee tier.
+    #[must_use]
+    pub const fn fee_tier(&self) -> FeeTier {
+        self.fee_tier
+    }
+
+    /// Returns the amplification coefficient.
+    #[must_use]
+    pub const fn amplification(&self) -> u32 {
+        self.amplification
+    }
+
+    /// Returns the initial reserve of token A.
+    pub const fn reserve_a(&self) -> Amount {
+        self.reserve_a
+    }
+
+    /// Returns the initial reserve of token B.
+    pub const fn reserve_b(&self) -> Amount {
+        self.reserve_b
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic)]
+mod tests {
+    use super::*;
+    use crate::domain::{BasisPoints, Decimals, Token, TokenAddress};
+
+    fn make_pair() -> TokenPair {
+        let Ok(d6) = Decimals::new(6) else {
+            panic!("valid decimals");
+        };
+        let Ok(d18) = Decimals::new(18) else {
+            panic!("valid decimals");
+        };
+        let tok_a = Token::new(TokenAddress::from_bytes([1u8; 32]), d6);
+        let tok_b = Token::new(TokenAddress::from_bytes([2u8; 32]), d18);
+        let Ok(pair) = TokenPair::new(tok_a, tok_b) else {
+            panic!("expected valid pair");
+        };
+        pair
+    }
+
+    fn fee() -> FeeTier {
+        FeeTier::new(BasisPoints::new(30))
+    }
+
+    #[test]
+    fn valid_config() {
+        let result = HybridConfig::new(
+            make_pair(),
+            fee(),
+            100,
+            Amount::new(1_000_000),
+            Amount::new(1_000_000),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn zero_amplification_rejected() {
+        let result = HybridConfig::new(
+            make_pair(),
+            fee(),
+            0,
+            Amount::new(1_000),
+            Amount::new(1_000),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn zero_reserve_a_rejected() {
+        let result = HybridConfig::new(make_pair(), fee(), 100, Amount::ZERO, Amount::new(1_000));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn zero_reserve_b_rejected() {
+        let result = HybridConfig::new(make_pair(), fee(), 100, Amount::new(1_000), Amount::ZERO);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn accessors() {
+        let pair = make_pair();
+        let f = fee();
+        let Ok(cfg) = HybridConfig::new(pair, f, 200, Amount::new(500), Amount::new(600)) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(*cfg.token_pair(), pair);
+        assert_eq!(cfg.fee_tier(), f);
+        assert_eq!(cfg.amplification(), 200);
+        assert_eq!(cfg.reserve_a(), Amount::new(500));
+        assert_eq!(cfg.reserve_b(), Amount::new(600));
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,5 +1,21 @@
 //! Pool configuration enums and structs.
 //!
-//! This module contains the `AmmConfig` enum — the top-level declarative
+//! This module contains the [`AmmConfig`] enum — the top-level declarative
 //! blueprint for creating any pool type — along with per-pool configuration
 //! structs that define the parameters for each AMM family.
+
+mod amm_config;
+mod clmm;
+mod constant_product;
+mod dynamic;
+mod hybrid;
+mod order_book;
+mod weighted;
+
+pub use amm_config::AmmConfig;
+pub use clmm::ClmmConfig;
+pub use constant_product::ConstantProductConfig;
+pub use dynamic::DynamicConfig;
+pub use hybrid::HybridConfig;
+pub use order_book::OrderBookConfig;
+pub use weighted::WeightedConfig;

--- a/src/config/order_book.rs
+++ b/src/config/order_book.rs
@@ -1,0 +1,145 @@
+//! Configuration for Order Book hybrid AMM pools (Phoenix style).
+
+use crate::domain::{Amount, FeeTier, TokenPair};
+use crate::error::AmmError;
+
+/// Configuration for a hybrid AMM/CLOB (Central Limit Order Book) pool.
+///
+/// Defines the immutable parameters for a Phoenix-style order book pool:
+/// token pair, fee tier, and minimum increments.
+///
+/// # Constraints
+///
+/// - All limit orders must be placed at prices that are multiples of `tick_size`.
+/// - All quantities must be multiples of `lot_size`.
+///
+/// # Validation
+///
+/// - Both `tick_size` and `lot_size` must be non-zero.
+/// - The token pair is validated at [`TokenPair`] construction time.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OrderBookConfig {
+    token_pair: TokenPair,
+    fee_tier: FeeTier,
+    tick_size: Amount,
+    lot_size: Amount,
+}
+
+impl OrderBookConfig {
+    /// Creates a new `OrderBookConfig`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AmmError::InvalidConfiguration`] if `tick_size` or
+    /// `lot_size` is zero.
+    pub fn new(
+        token_pair: TokenPair,
+        fee_tier: FeeTier,
+        tick_size: Amount,
+        lot_size: Amount,
+    ) -> Result<Self, AmmError> {
+        let config = Self {
+            token_pair,
+            fee_tier,
+            tick_size,
+            lot_size,
+        };
+        config.validate()?;
+        Ok(config)
+    }
+
+    /// Validates all configuration invariants.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AmmError::InvalidConfiguration`] if `tick_size` or
+    /// `lot_size` is zero.
+    pub fn validate(&self) -> Result<(), AmmError> {
+        if self.tick_size.is_zero() {
+            return Err(AmmError::InvalidConfiguration("tick size must be non-zero"));
+        }
+        if self.lot_size.is_zero() {
+            return Err(AmmError::InvalidConfiguration("lot size must be non-zero"));
+        }
+        Ok(())
+    }
+
+    /// Returns the token pair.
+    #[must_use]
+    pub const fn token_pair(&self) -> &TokenPair {
+        &self.token_pair
+    }
+
+    /// Returns the fee tier.
+    #[must_use]
+    pub const fn fee_tier(&self) -> FeeTier {
+        self.fee_tier
+    }
+
+    /// Returns the minimum price increment.
+    pub const fn tick_size(&self) -> Amount {
+        self.tick_size
+    }
+
+    /// Returns the minimum quantity increment.
+    pub const fn lot_size(&self) -> Amount {
+        self.lot_size
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic)]
+mod tests {
+    use super::*;
+    use crate::domain::{BasisPoints, Decimals, Token, TokenAddress};
+
+    fn make_pair() -> TokenPair {
+        let Ok(d6) = Decimals::new(6) else {
+            panic!("valid decimals");
+        };
+        let Ok(d18) = Decimals::new(18) else {
+            panic!("valid decimals");
+        };
+        let tok_a = Token::new(TokenAddress::from_bytes([1u8; 32]), d6);
+        let tok_b = Token::new(TokenAddress::from_bytes([2u8; 32]), d18);
+        let Ok(pair) = TokenPair::new(tok_a, tok_b) else {
+            panic!("expected valid pair");
+        };
+        pair
+    }
+
+    fn fee() -> FeeTier {
+        FeeTier::new(BasisPoints::new(30))
+    }
+
+    #[test]
+    fn valid_config() {
+        let result = OrderBookConfig::new(make_pair(), fee(), Amount::new(1), Amount::new(10));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn zero_tick_size_rejected() {
+        let result = OrderBookConfig::new(make_pair(), fee(), Amount::ZERO, Amount::new(10));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn zero_lot_size_rejected() {
+        let result = OrderBookConfig::new(make_pair(), fee(), Amount::new(1), Amount::ZERO);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn accessors() {
+        let pair = make_pair();
+        let f = fee();
+        let Ok(cfg) = OrderBookConfig::new(pair, f, Amount::new(5), Amount::new(100)) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(*cfg.token_pair(), pair);
+        assert_eq!(cfg.fee_tier(), f);
+        assert_eq!(cfg.tick_size(), Amount::new(5));
+        assert_eq!(cfg.lot_size(), Amount::new(100));
+    }
+}

--- a/src/config/weighted.rs
+++ b/src/config/weighted.rs
@@ -1,0 +1,252 @@
+//! Configuration for Weighted AMM pools (Balancer style).
+
+use crate::domain::{Amount, BasisPoints, FeeTier, Token};
+use crate::error::AmmError;
+
+/// Configuration for a Weighted pool supporting N tokens with custom
+/// weight distributions (Balancer style).
+///
+/// # Invariant
+///
+/// ```text
+/// ∏(Bᵢ ^ Wᵢ) = k
+/// ```
+///
+/// where `Bᵢ` is the balance of token `i` and `Wᵢ` is its normalized
+/// weight (as a fraction, e.g., 0.5 for 50%).
+///
+/// # Validation
+///
+/// - `tokens.len() == weights.len() == balances.len()`
+/// - At least 2 tokens.
+/// - No duplicate token addresses.
+/// - Weights must sum to exactly 10 000 basis points.
+/// - All balances must be non-zero.
+#[derive(Debug, Clone, PartialEq)]
+pub struct WeightedConfig {
+    tokens: Vec<Token>,
+    weights: Vec<BasisPoints>,
+    fee_tier: FeeTier,
+    balances: Vec<Amount>,
+}
+
+impl WeightedConfig {
+    /// Creates a new `WeightedConfig`.
+    ///
+    /// # Arguments
+    ///
+    /// - `tokens` — the tokens in the pool (typically 2–8).
+    /// - `weights` — the weight of each token in basis points; must sum
+    ///   to 10 000.
+    /// - `balances` — the initial balance of each token; all must be
+    ///   non-zero.
+    ///
+    /// # Errors
+    ///
+    /// - [`AmmError::InvalidConfiguration`] if vector lengths differ, or
+    ///   fewer than 2 tokens, or duplicate token addresses, or weights do
+    ///   not sum to 10 000.
+    /// - [`AmmError::ZeroReserve`] if any balance is zero.
+    pub fn new(
+        tokens: Vec<Token>,
+        weights: Vec<BasisPoints>,
+        fee_tier: FeeTier,
+        balances: Vec<Amount>,
+    ) -> Result<Self, AmmError> {
+        let config = Self {
+            tokens,
+            weights,
+            fee_tier,
+            balances,
+        };
+        config.validate()?;
+        Ok(config)
+    }
+
+    /// Validates all configuration invariants.
+    ///
+    /// # Errors
+    ///
+    /// - [`AmmError::InvalidConfiguration`] if vector lengths differ, or
+    ///   fewer than 2 tokens, or duplicate token addresses, or weights do
+    ///   not sum to 10 000.
+    /// - [`AmmError::ZeroReserve`] if any balance is zero.
+    pub fn validate(&self) -> Result<(), AmmError> {
+        if self.tokens.len() != self.weights.len() || self.tokens.len() != self.balances.len() {
+            return Err(AmmError::InvalidConfiguration(
+                "tokens, weights, and balances must have equal length",
+            ));
+        }
+        if self.tokens.len() < 2 {
+            return Err(AmmError::InvalidConfiguration(
+                "at least 2 tokens are required",
+            ));
+        }
+
+        // Check for duplicate token addresses (O(n²), fine for ≤8 tokens).
+        let mut iter = self.tokens.iter();
+        while let Some(token) = iter.next() {
+            for other in iter.clone() {
+                if token.address() == other.address() {
+                    return Err(AmmError::InvalidConfiguration(
+                        "duplicate token addresses are not allowed",
+                    ));
+                }
+            }
+        }
+
+        let weight_sum: u32 = self.weights.iter().map(|w| w.get()).sum();
+        if weight_sum != 10_000 {
+            return Err(AmmError::InvalidConfiguration(
+                "weights must sum to exactly 10000 basis points",
+            ));
+        }
+
+        for balance in &self.balances {
+            if balance.is_zero() {
+                return Err(AmmError::ZeroReserve);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Returns a reference to the tokens.
+    #[must_use]
+    pub fn tokens(&self) -> &[Token] {
+        &self.tokens
+    }
+
+    /// Returns a reference to the weights.
+    #[must_use]
+    pub fn weights(&self) -> &[BasisPoints] {
+        &self.weights
+    }
+
+    /// Returns the fee tier.
+    #[must_use]
+    pub const fn fee_tier(&self) -> FeeTier {
+        self.fee_tier
+    }
+
+    /// Returns a reference to the initial balances.
+    pub fn balances(&self) -> &[Amount] {
+        &self.balances
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic)]
+#[allow(clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+    use crate::domain::{Decimals, TokenAddress};
+
+    fn tok(byte: u8, dec: u8) -> Token {
+        let Ok(d) = Decimals::new(dec) else {
+            panic!("valid decimals");
+        };
+        Token::new(TokenAddress::from_bytes([byte; 32]), d)
+    }
+
+    fn fee() -> FeeTier {
+        FeeTier::new(BasisPoints::new(30))
+    }
+
+    fn bps(v: u32) -> BasisPoints {
+        BasisPoints::new(v)
+    }
+
+    #[test]
+    fn valid_two_token_pool() {
+        let result = WeightedConfig::new(
+            vec![tok(1, 6), tok(2, 18)],
+            vec![bps(5_000), bps(5_000)],
+            fee(),
+            vec![Amount::new(1_000), Amount::new(2_000)],
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn valid_three_token_pool() {
+        let result = WeightedConfig::new(
+            vec![tok(1, 6), tok(2, 18), tok(3, 8)],
+            vec![bps(3_333), bps(3_333), bps(3_334)],
+            fee(),
+            vec![Amount::new(100), Amount::new(200), Amount::new(300)],
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn fewer_than_two_tokens_rejected() {
+        let result = WeightedConfig::new(
+            vec![tok(1, 6)],
+            vec![bps(10_000)],
+            fee(),
+            vec![Amount::new(1_000)],
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn mismatched_lengths_rejected() {
+        let result = WeightedConfig::new(
+            vec![tok(1, 6), tok(2, 18)],
+            vec![bps(5_000)],
+            fee(),
+            vec![Amount::new(1_000), Amount::new(2_000)],
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn duplicate_tokens_rejected() {
+        let result = WeightedConfig::new(
+            vec![tok(1, 6), tok(1, 18)],
+            vec![bps(5_000), bps(5_000)],
+            fee(),
+            vec![Amount::new(1_000), Amount::new(2_000)],
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn weights_not_summing_to_10000_rejected() {
+        let result = WeightedConfig::new(
+            vec![tok(1, 6), tok(2, 18)],
+            vec![bps(4_000), bps(4_000)],
+            fee(),
+            vec![Amount::new(1_000), Amount::new(2_000)],
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn zero_balance_rejected() {
+        let result = WeightedConfig::new(
+            vec![tok(1, 6), tok(2, 18)],
+            vec![bps(5_000), bps(5_000)],
+            fee(),
+            vec![Amount::new(1_000), Amount::ZERO],
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn accessors() {
+        let Ok(cfg) = WeightedConfig::new(
+            vec![tok(1, 6), tok(2, 18)],
+            vec![bps(5_000), bps(5_000)],
+            fee(),
+            vec![Amount::new(100), Amount::new(200)],
+        ) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(cfg.tokens().len(), 2);
+        assert_eq!(cfg.weights().len(), 2);
+        assert_eq!(cfg.balances().len(), 2);
+        assert_eq!(cfg.fee_tier(), fee());
+    }
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -32,7 +32,10 @@ pub use crate::math::FixedPointArithmetic;
 pub use crate::math::FloatArithmetic;
 
 // Re-export configuration
-// pub use crate::config::AmmConfig;
+pub use crate::config::{
+    AmmConfig, ClmmConfig, ConstantProductConfig, DynamicConfig, HybridConfig, OrderBookConfig,
+    WeightedConfig,
+};
 
 // Re-export error types
 pub use crate::error::{AmmError, Result};


### PR DESCRIPTION
## Summary

Define the top-level `AmmConfig` enum and all 6 pool-specific configuration structs that serve as the declarative blueprint for creating any pool type.

## Changes

- **src/config/amm_config.rs**: `AmmConfig` enum with 6 variants:
  - `ConstantProduct(ConstantProductConfig)`
  - `Clmm(ClmmConfig)`
  - `Hybrid(HybridConfig)`
  - `Weighted(WeightedConfig)`
  - `Dynamic(DynamicConfig)`
  - `OrderBook(OrderBookConfig)`
  - `validate()` delegates to inner config validation
  - `is_*()` helper methods + `Display` impl

- **src/config/constant_product.rs**: `ConstantProductConfig` — token pair, fee tier, two reserves. Validates non-zero reserves.

- **src/config/clmm.rs**: `ClmmConfig` — token pair, fee tier, tick spacing, current tick, positions (`Vec<Position>`). Validates tick spacing > 0.

- **src/config/hybrid.rs**: `HybridConfig` — token pair, fee tier, amplification (`u32`), two reserves. Validates amplification > 0 and non-zero reserves.

- **src/config/weighted.rs**: `WeightedConfig` — tokens, weights, fee tier, balances (all `Vec`). Validates equal lengths, ≥2 tokens, no duplicates, weights sum to 10000, non-zero balances.

- **src/config/dynamic.rs**: `DynamicConfig` — token pair, fee tier, oracle price, slippage coefficient (`f64` in `[0,1]`), two reserves. Validates coefficient range, positive oracle price, non-zero reserves.

- **src/config/order_book.rs**: `OrderBookConfig` — token pair, fee tier, tick size, lot size. Validates non-zero tick/lot sizes.

- **src/config/mod.rs**: Added 7 submodules and re-exports.
- **src/prelude.rs**: Added all config type re-exports.

## Technical Decisions

- **Private fields + constructors**: Each config struct uses private fields with a `new()` constructor that calls `validate()` internally. This ensures all instances are valid on construction while allowing re-validation after deserialization.
- **`u32` for amplification**: Used directly rather than a newtype for now; can be extracted to `AmpCoefficient` later if needed.
- **`f64` for slippage coefficient**: Raw `f64` with range validation in `[0.0, 1.0]`. Since `Price` already wraps `f64`, `DynamicConfig` can only derive `PartialEq` (not `Eq`), which applies to `AmmConfig` as well.
- **Iterator-based duplicate check**: `WeightedConfig` uses `iter().clone()` pattern instead of index-based loops to satisfy `clippy::indexing_slicing`.
- **No serde yet**: Serde support can be added behind a feature flag in a follow-up.
- **Issues #18–#23**: Will add comprehensive tests and potentially enhanced validation for each individual config struct.

## Testing

- [x] Unit tests for each config struct (valid construction, invalid inputs, accessors)
- [x] Unit tests for `AmmConfig` (variant matching, validate delegation, display)
- [x] Manual testing performed (`make lint-fix` + `make pre-push` — 395 tests + 24 doc-tests passed, zero warnings)

## Checklist

- [x] Code follows `.internalDoc/09-RUST-GUIDELINES.md`
- [x] All public items have `///` documentation
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] Feature-gated code compiles with and without its feature
- [x] No `.unwrap()`, `.expect()`, or panics in library code

Closes #17