### PR TITLE
M5 #19: Implement ClmmConfig with tick/position validation

### DIFF
--- a/src/config/clmm.rs
+++ b/src/config/clmm.rs
@@ -16,10 +16,14 @@ use crate::error::AmmError;
 ///
 /// # Validation
 ///
+/// - Fee tier must be a valid percentage (0–10 000 basis points).
 /// - `tick_spacing` must be greater than zero.
-/// - `current_tick` must be within the valid tick range.
+/// - `current_tick` must be aligned to `tick_spacing`.
+/// - Each position's `lower_tick` and `upper_tick` must be aligned to
+///   `tick_spacing`.
 /// - Each position must have `lower_tick < upper_tick` (enforced by
 ///   [`Position`] construction).
+/// - The token pair is validated at [`TokenPair`] construction time.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ClmmConfig {
     token_pair: TokenPair,
@@ -41,7 +45,11 @@ impl ClmmConfig {
     ///
     /// # Errors
     ///
-    /// Returns [`AmmError::InvalidConfiguration`] if `tick_spacing` is zero.
+    /// - [`AmmError::InvalidFee`] if the fee tier exceeds 100% (10 000 basis points).
+    /// - [`AmmError::InvalidConfiguration`] if `tick_spacing` is zero.
+    /// - [`AmmError::InvalidTick`] if `current_tick` is not aligned to `tick_spacing`.
+    /// - [`AmmError::InvalidTickRange`] if any position tick is not aligned to
+    ///   `tick_spacing`.
     pub fn new(
         token_pair: TokenPair,
         fee_tier: FeeTier,
@@ -64,12 +72,39 @@ impl ClmmConfig {
     ///
     /// # Errors
     ///
-    /// Returns [`AmmError::InvalidConfiguration`] if `tick_spacing` is zero.
+    /// - [`AmmError::InvalidFee`] if the fee tier exceeds 100% (10 000 basis points).
+    /// - [`AmmError::InvalidConfiguration`] if `tick_spacing` is zero.
+    /// - [`AmmError::InvalidTick`] if `current_tick` is not aligned to `tick_spacing`.
+    /// - [`AmmError::InvalidTickRange`] if any position tick is not aligned to
+    ///   `tick_spacing`.
     pub fn validate(&self) -> Result<(), AmmError> {
+        if !self.fee_tier.basis_points().is_valid_percent() {
+            return Err(AmmError::InvalidFee(
+                "fee tier must not exceed 10000 basis points (100%)",
+            ));
+        }
         if self.tick_spacing == 0 {
             return Err(AmmError::InvalidConfiguration(
                 "tick spacing must be greater than zero",
             ));
+        }
+        let spacing = self.tick_spacing as i32;
+        if self.current_tick.get() % spacing != 0 {
+            return Err(AmmError::InvalidTick(
+                "current tick must be aligned to tick spacing",
+            ));
+        }
+        for pos in &self.positions {
+            if pos.lower_tick().get() % spacing != 0 {
+                return Err(AmmError::InvalidTickRange(
+                    "position lower tick must be aligned to tick spacing",
+                ));
+            }
+            if pos.upper_tick().get() % spacing != 0 {
+                return Err(AmmError::InvalidTickRange(
+                    "position upper tick must be aligned to tick spacing",
+                ));
+            }
         }
         Ok(())
     }
@@ -107,9 +142,12 @@ impl ClmmConfig {
 
 #[cfg(test)]
 #[allow(clippy::panic)]
+#[allow(clippy::indexing_slicing)]
 mod tests {
     use super::*;
     use crate::domain::{BasisPoints, Decimals, Liquidity, Token, TokenAddress};
+
+    // -- helpers --------------------------------------------------------------
 
     fn make_pair() -> TokenPair {
         let Ok(d6) = Decimals::new(6) else {
@@ -137,6 +175,22 @@ mod tests {
         t
     }
 
+    fn pos(lower: i32, upper: i32, liq: u128) -> Position {
+        let Ok(p) = Position::new(tick(lower), tick(upper), Liquidity::new(liq)) else {
+            panic!("expected valid position");
+        };
+        p
+    }
+
+    fn valid_cfg() -> ClmmConfig {
+        let Ok(cfg) = ClmmConfig::new(make_pair(), fee(), 10, tick(0), vec![]) else {
+            panic!("expected Ok");
+        };
+        cfg
+    }
+
+    // -- valid construction ---------------------------------------------------
+
     #[test]
     fn valid_config_no_positions() {
         let result = ClmmConfig::new(make_pair(), fee(), 10, tick(0), vec![]);
@@ -144,31 +198,203 @@ mod tests {
     }
 
     #[test]
-    fn valid_config_with_positions() {
-        let Ok(pos) = Position::new(tick(-100), tick(100), Liquidity::new(1_000)) else {
-            panic!("expected valid position");
-        };
-        let result = ClmmConfig::new(make_pair(), fee(), 10, tick(0), vec![pos]);
+    fn valid_config_with_aligned_positions() {
+        let result = ClmmConfig::new(
+            make_pair(),
+            fee(),
+            10,
+            tick(0),
+            vec![pos(-100, 100, 1_000), pos(-200, 200, 500)],
+        );
         assert!(result.is_ok());
     }
 
     #[test]
+    fn valid_with_spacing_one() {
+        let result = ClmmConfig::new(make_pair(), fee(), 1, tick(7), vec![pos(-3, 5, 100)]);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn valid_with_spacing_60() {
+        let result = ClmmConfig::new(make_pair(), fee(), 60, tick(120), vec![pos(-60, 180, 1)]);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn valid_with_spacing_200() {
+        let result = ClmmConfig::new(make_pair(), fee(), 200, tick(0), vec![pos(-400, 600, 1)]);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn valid_with_standard_fee_tiers() {
+        for tier in [
+            FeeTier::TIER_0_01_PERCENT,
+            FeeTier::TIER_0_05_PERCENT,
+            FeeTier::TIER_0_30_PERCENT,
+            FeeTier::TIER_1_00_PERCENT,
+        ] {
+            let result = ClmmConfig::new(make_pair(), tier, 1, tick(0), vec![]);
+            assert!(result.is_ok());
+        }
+    }
+
+    #[test]
+    fn valid_with_zero_fee() {
+        let zero_fee = FeeTier::new(BasisPoints::new(0));
+        let result = ClmmConfig::new(make_pair(), zero_fee, 1, tick(0), vec![]);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn valid_with_max_valid_fee() {
+        let max_fee = FeeTier::new(BasisPoints::new(10_000));
+        let result = ClmmConfig::new(make_pair(), max_fee, 1, tick(0), vec![]);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn valid_with_negative_current_tick_aligned() {
+        let result = ClmmConfig::new(make_pair(), fee(), 10, tick(-100), vec![]);
+        assert!(result.is_ok());
+    }
+
+    // -- fee_tier validation --------------------------------------------------
+
+    #[test]
+    fn fee_exceeding_100_percent_rejected() {
+        let bad_fee = FeeTier::new(BasisPoints::new(10_001));
+        let result = ClmmConfig::new(make_pair(), bad_fee, 10, tick(0), vec![]);
+        assert!(matches!(result, Err(AmmError::InvalidFee(_))));
+    }
+
+    #[test]
+    fn fee_way_above_range_rejected() {
+        let bad_fee = FeeTier::new(BasisPoints::new(u32::MAX));
+        let result = ClmmConfig::new(make_pair(), bad_fee, 10, tick(0), vec![]);
+        assert!(matches!(result, Err(AmmError::InvalidFee(_))));
+    }
+
+    // -- tick_spacing validation ----------------------------------------------
+
+    #[test]
     fn zero_tick_spacing_rejected() {
         let result = ClmmConfig::new(make_pair(), fee(), 0, tick(0), vec![]);
-        assert!(result.is_err());
+        assert!(matches!(result, Err(AmmError::InvalidConfiguration(_))));
     }
+
+    // -- current_tick alignment -----------------------------------------------
+
+    #[test]
+    fn current_tick_not_aligned_rejected() {
+        let result = ClmmConfig::new(make_pair(), fee(), 10, tick(5), vec![]);
+        assert!(matches!(result, Err(AmmError::InvalidTick(_))));
+    }
+
+    #[test]
+    fn current_tick_off_by_one_rejected() {
+        let result = ClmmConfig::new(make_pair(), fee(), 60, tick(1), vec![]);
+        assert!(matches!(result, Err(AmmError::InvalidTick(_))));
+    }
+
+    #[test]
+    fn negative_current_tick_not_aligned_rejected() {
+        let result = ClmmConfig::new(make_pair(), fee(), 10, tick(-5), vec![]);
+        assert!(matches!(result, Err(AmmError::InvalidTick(_))));
+    }
+
+    // -- position tick alignment ----------------------------------------------
+
+    #[test]
+    fn position_lower_tick_not_aligned_rejected() {
+        let p = pos(-5, 10, 100); // lower=-5 not aligned to spacing=10
+        let result = ClmmConfig::new(make_pair(), fee(), 10, tick(0), vec![p]);
+        assert!(matches!(result, Err(AmmError::InvalidTickRange(_))));
+    }
+
+    #[test]
+    fn position_upper_tick_not_aligned_rejected() {
+        let p = pos(-10, 15, 100); // upper=15 not aligned to spacing=10
+        let result = ClmmConfig::new(make_pair(), fee(), 10, tick(0), vec![p]);
+        assert!(matches!(result, Err(AmmError::InvalidTickRange(_))));
+    }
+
+    #[test]
+    fn second_position_misaligned_rejected() {
+        let good = pos(-100, 100, 500);
+        let bad = pos(-10, 15, 100); // upper=15 not aligned
+        let result = ClmmConfig::new(make_pair(), fee(), 10, tick(0), vec![good, bad]);
+        assert!(matches!(result, Err(AmmError::InvalidTickRange(_))));
+    }
+
+    #[test]
+    fn position_negative_ticks_not_aligned_rejected() {
+        let p = pos(-7, 3, 100); // both misaligned to spacing=10
+        let result = ClmmConfig::new(make_pair(), fee(), 10, tick(0), vec![p]);
+        assert!(matches!(result, Err(AmmError::InvalidTickRange(_))));
+    }
+
+    // -- validate on existing instance ----------------------------------------
+
+    #[test]
+    fn validate_on_valid_config_succeeds() {
+        let cfg = valid_cfg();
+        assert!(cfg.validate().is_ok());
+    }
+
+    // -- accessors ------------------------------------------------------------
 
     #[test]
     fn accessors() {
         let pair = make_pair();
         let f = fee();
-        let Ok(cfg) = ClmmConfig::new(pair, f, 60, tick(500), vec![]) else {
+        let p = pos(-60, 60, 1_000);
+        let Ok(cfg) = ClmmConfig::new(pair, f, 60, tick(0), vec![p]) else {
             panic!("expected Ok");
         };
         assert_eq!(*cfg.token_pair(), pair);
         assert_eq!(cfg.fee_tier(), f);
         assert_eq!(cfg.tick_spacing(), 60);
-        assert_eq!(cfg.current_tick(), tick(500));
+        assert_eq!(cfg.current_tick(), tick(0));
+        assert_eq!(cfg.positions().len(), 1);
+        assert_eq!(cfg.positions()[0], p);
+    }
+
+    #[test]
+    fn accessors_empty_positions() {
+        let Ok(cfg) = ClmmConfig::new(make_pair(), fee(), 10, tick(0), vec![]) else {
+            panic!("expected Ok");
+        };
         assert!(cfg.positions().is_empty());
+    }
+
+    // -- Clone & PartialEq ---------------------------------------------------
+
+    #[test]
+    fn clone_equality() {
+        let cfg = valid_cfg();
+        let cloned = cfg.clone();
+        assert_eq!(cfg, cloned);
+    }
+
+    #[test]
+    fn different_tick_spacing_not_equal() {
+        let Ok(a) = ClmmConfig::new(make_pair(), fee(), 10, tick(0), vec![]) else {
+            panic!("expected Ok");
+        };
+        let Ok(b) = ClmmConfig::new(make_pair(), fee(), 60, tick(0), vec![]) else {
+            panic!("expected Ok");
+        };
+        assert_ne!(a, b);
+    }
+
+    // -- Debug ----------------------------------------------------------------
+
+    #[test]
+    fn debug_format_contains_struct_name() {
+        let cfg = valid_cfg();
+        let dbg = format!("{cfg:?}");
+        assert!(dbg.contains("ClmmConfig"));
     }
 }


### PR DESCRIPTION
## Summary

Enhance `ClmmConfig` with comprehensive validation per the 03-CONFIG.md spec: fee tier range validation, current tick alignment to tick spacing, and position tick alignment to tick spacing.

## Changes

- **src/config/clmm.rs**:
  - Added fee tier validation: reject fee tiers exceeding 10 000 basis points (100%) via `BasisPoints::is_valid_percent()`, returning `AmmError::InvalidFee`
  - Added current tick alignment: `current_tick` must be a multiple of `tick_spacing`, returning `AmmError::InvalidTick`
  - Added position tick alignment: both `lower_tick` and `upper_tick` of every position must be multiples of `tick_spacing`, returning `AmmError::InvalidTickRange`
  - Validation order: fee tier → tick_spacing > 0 → current_tick alignment → position tick alignment
  - Updated `///` docs on `new()` and `validate()` to document all error variants
  - Comprehensive test suite (26 tests total):
    - **Valid construction**: no positions, aligned positions, spacing 1/60/200, standard fee tiers, zero/max fee, negative aligned tick
    - **Fee validation**: 10001 bps rejected, `u32::MAX` rejected
    - **Tick spacing**: zero rejected
    - **Current tick alignment**: misaligned positive/negative ticks, off-by-one
    - **Position tick alignment**: lower misaligned, upper misaligned, second position misaligned, both ticks misaligned
    - **validate()** on existing instance
    - **Accessors** (with/without positions)
    - **Clone** equality, **PartialEq** inequality, **Debug** format

## Technical Decisions

- **Tick alignment via modulo**: Uses `tick.get() % spacing == 0` to validate alignment. The `tick_spacing` field is `u32` and is cast to `i32` for the modulo operation. This is safe because tick spacing values are small (standard: 1, 10, 60, 200) and won't exceed `i32::MAX`.
- **Validation order mirrors priority**: Fee tier is checked first (broad config error), then tick spacing (structural), then current tick alignment (specific), then position ticks (per-position).
- **Position tick_lower < tick_upper**: Already enforced by `Position::new()` at construction time, so not re-validated here.

## Testing

- [x] Unit tests added (26 tests covering all validation paths)
- [x] Manual testing performed (`make lint-fix` + `make pre-push` — all tests passed, zero warnings)

## Checklist

- [x] Code follows `.internalDoc/09-RUST-GUIDELINES.md`
- [x] All public items have `///` documentation
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] Feature-gated code compiles with and without its feature
- [x] No `.unwrap()`, `.expect()`, or panics in library code

Closes #19