### PR TITLE
M5 #20: Implement HybridConfig (StableSwap) with amplification validation

### DIFF
--- a/src/config/hybrid.rs
+++ b/src/config/hybrid.rs
@@ -26,8 +26,10 @@ use crate::error::AmmError;
 ///
 /// # Validation
 ///
+/// - Fee tier must be a valid percentage (0–10 000 basis points).
+/// - Amplification must be in the range `1..=10_000`.
 /// - Both reserves must be non-zero.
-/// - Amplification must be greater than zero.
+/// - The token pair is validated at [`TokenPair`] construction time.
 #[derive(Debug, Clone, PartialEq)]
 pub struct HybridConfig {
     token_pair: TokenPair,
@@ -38,16 +40,20 @@ pub struct HybridConfig {
 }
 
 impl HybridConfig {
+    /// Maximum allowed amplification coefficient.
+    const MAX_AMPLIFICATION: u32 = 10_000;
+
     /// Creates a new `HybridConfig`.
     ///
     /// # Arguments
     ///
     /// - `amplification` — the StableSwap amplification coefficient
-    ///   (must be > 0, typically 50–5000).
+    ///   (must be in `1..=10_000`, typically 50–5000).
     ///
     /// # Errors
     ///
-    /// - [`AmmError::InvalidConfiguration`] if `amplification` is zero.
+    /// - [`AmmError::InvalidFee`] if the fee tier exceeds 100% (10 000 basis points).
+    /// - [`AmmError::InvalidConfiguration`] if `amplification` is zero or exceeds 10 000.
     /// - [`AmmError::ZeroReserve`] if either reserve is zero.
     pub fn new(
         token_pair: TokenPair,
@@ -71,12 +77,18 @@ impl HybridConfig {
     ///
     /// # Errors
     ///
-    /// - [`AmmError::InvalidConfiguration`] if `amplification` is zero.
+    /// - [`AmmError::InvalidFee`] if the fee tier exceeds 100% (10 000 basis points).
+    /// - [`AmmError::InvalidConfiguration`] if `amplification` is zero or exceeds 10 000.
     /// - [`AmmError::ZeroReserve`] if either reserve is zero.
     pub fn validate(&self) -> Result<(), AmmError> {
-        if self.amplification == 0 {
+        if !self.fee_tier.basis_points().is_valid_percent() {
+            return Err(AmmError::InvalidFee(
+                "fee tier must not exceed 10000 basis points (100%)",
+            ));
+        }
+        if self.amplification == 0 || self.amplification > Self::MAX_AMPLIFICATION {
             return Err(AmmError::InvalidConfiguration(
-                "amplification must be greater than zero",
+                "amplification must be in the range 1..=10000",
             ));
         }
         if self.reserve_a.is_zero() {
@@ -123,6 +135,8 @@ mod tests {
     use super::*;
     use crate::domain::{BasisPoints, Decimals, Token, TokenAddress};
 
+    // -- helpers --------------------------------------------------------------
+
     fn make_pair() -> TokenPair {
         let Ok(d6) = Decimals::new(6) else {
             panic!("valid decimals");
@@ -142,6 +156,21 @@ mod tests {
         FeeTier::new(BasisPoints::new(30))
     }
 
+    fn valid_cfg() -> HybridConfig {
+        let Ok(cfg) = HybridConfig::new(
+            make_pair(),
+            fee(),
+            100,
+            Amount::new(1_000_000),
+            Amount::new(1_000_000),
+        ) else {
+            panic!("expected Ok");
+        };
+        cfg
+    }
+
+    // -- valid construction ---------------------------------------------------
+
     #[test]
     fn valid_config() {
         let result = HybridConfig::new(
@@ -155,6 +184,137 @@ mod tests {
     }
 
     #[test]
+    fn valid_with_amplification_one() {
+        let result = HybridConfig::new(
+            make_pair(),
+            fee(),
+            1,
+            Amount::new(1_000),
+            Amount::new(1_000),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn valid_with_max_amplification() {
+        let result = HybridConfig::new(
+            make_pair(),
+            fee(),
+            10_000,
+            Amount::new(1_000),
+            Amount::new(1_000),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn valid_with_typical_stablecoin_amplification() {
+        for amp in [50, 100, 200, 500, 1_000, 5_000] {
+            let result = HybridConfig::new(
+                make_pair(),
+                fee(),
+                amp,
+                Amount::new(1_000),
+                Amount::new(1_000),
+            );
+            assert!(result.is_ok());
+        }
+    }
+
+    #[test]
+    fn valid_with_standard_fee_tiers() {
+        for tier in [
+            FeeTier::TIER_0_01_PERCENT,
+            FeeTier::TIER_0_05_PERCENT,
+            FeeTier::TIER_0_30_PERCENT,
+            FeeTier::TIER_1_00_PERCENT,
+        ] {
+            let result = HybridConfig::new(
+                make_pair(),
+                tier,
+                100,
+                Amount::new(1_000),
+                Amount::new(1_000),
+            );
+            assert!(result.is_ok());
+        }
+    }
+
+    #[test]
+    fn valid_with_zero_fee() {
+        let zero_fee = FeeTier::new(BasisPoints::new(0));
+        let result = HybridConfig::new(
+            make_pair(),
+            zero_fee,
+            100,
+            Amount::new(1_000),
+            Amount::new(1_000),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn valid_with_max_valid_fee() {
+        let max_fee = FeeTier::new(BasisPoints::new(10_000));
+        let result = HybridConfig::new(
+            make_pair(),
+            max_fee,
+            100,
+            Amount::new(1_000),
+            Amount::new(1_000),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn valid_with_large_reserves() {
+        let result = HybridConfig::new(
+            make_pair(),
+            fee(),
+            100,
+            Amount::new(u128::MAX),
+            Amount::new(u128::MAX),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn valid_with_minimum_reserves() {
+        let result = HybridConfig::new(make_pair(), fee(), 1, Amount::new(1), Amount::new(1));
+        assert!(result.is_ok());
+    }
+
+    // -- fee_tier validation --------------------------------------------------
+
+    #[test]
+    fn fee_exceeding_100_percent_rejected() {
+        let bad_fee = FeeTier::new(BasisPoints::new(10_001));
+        let result = HybridConfig::new(
+            make_pair(),
+            bad_fee,
+            100,
+            Amount::new(1_000),
+            Amount::new(1_000),
+        );
+        assert!(matches!(result, Err(AmmError::InvalidFee(_))));
+    }
+
+    #[test]
+    fn fee_way_above_range_rejected() {
+        let bad_fee = FeeTier::new(BasisPoints::new(u32::MAX));
+        let result = HybridConfig::new(
+            make_pair(),
+            bad_fee,
+            100,
+            Amount::new(1_000),
+            Amount::new(1_000),
+        );
+        assert!(matches!(result, Err(AmmError::InvalidFee(_))));
+    }
+
+    // -- amplification validation ---------------------------------------------
+
+    #[test]
     fn zero_amplification_rejected() {
         let result = HybridConfig::new(
             make_pair(),
@@ -163,20 +323,62 @@ mod tests {
             Amount::new(1_000),
             Amount::new(1_000),
         );
-        assert!(result.is_err());
+        assert!(matches!(result, Err(AmmError::InvalidConfiguration(_))));
     }
+
+    #[test]
+    fn amplification_exceeding_max_rejected() {
+        let result = HybridConfig::new(
+            make_pair(),
+            fee(),
+            10_001,
+            Amount::new(1_000),
+            Amount::new(1_000),
+        );
+        assert!(matches!(result, Err(AmmError::InvalidConfiguration(_))));
+    }
+
+    #[test]
+    fn amplification_way_above_max_rejected() {
+        let result = HybridConfig::new(
+            make_pair(),
+            fee(),
+            u32::MAX,
+            Amount::new(1_000),
+            Amount::new(1_000),
+        );
+        assert!(matches!(result, Err(AmmError::InvalidConfiguration(_))));
+    }
+
+    // -- reserve validation ---------------------------------------------------
 
     #[test]
     fn zero_reserve_a_rejected() {
         let result = HybridConfig::new(make_pair(), fee(), 100, Amount::ZERO, Amount::new(1_000));
-        assert!(result.is_err());
+        assert!(matches!(result, Err(AmmError::ZeroReserve)));
     }
 
     #[test]
     fn zero_reserve_b_rejected() {
         let result = HybridConfig::new(make_pair(), fee(), 100, Amount::new(1_000), Amount::ZERO);
-        assert!(result.is_err());
+        assert!(matches!(result, Err(AmmError::ZeroReserve)));
     }
+
+    #[test]
+    fn both_reserves_zero_rejected() {
+        let result = HybridConfig::new(make_pair(), fee(), 100, Amount::ZERO, Amount::ZERO);
+        assert!(matches!(result, Err(AmmError::ZeroReserve)));
+    }
+
+    // -- validate on existing instance ----------------------------------------
+
+    #[test]
+    fn validate_on_valid_config_succeeds() {
+        let cfg = valid_cfg();
+        assert!(cfg.validate().is_ok());
+    }
+
+    // -- accessors ------------------------------------------------------------
 
     #[test]
     fn accessors() {
@@ -190,5 +392,46 @@ mod tests {
         assert_eq!(cfg.amplification(), 200);
         assert_eq!(cfg.reserve_a(), Amount::new(500));
         assert_eq!(cfg.reserve_b(), Amount::new(600));
+    }
+
+    // -- Clone & PartialEq ---------------------------------------------------
+
+    #[test]
+    fn clone_equality() {
+        let cfg = valid_cfg();
+        let cloned = cfg.clone();
+        assert_eq!(cfg, cloned);
+    }
+
+    #[test]
+    fn different_amplification_not_equal() {
+        let Ok(a) = HybridConfig::new(
+            make_pair(),
+            fee(),
+            100,
+            Amount::new(1_000),
+            Amount::new(1_000),
+        ) else {
+            panic!("expected Ok");
+        };
+        let Ok(b) = HybridConfig::new(
+            make_pair(),
+            fee(),
+            200,
+            Amount::new(1_000),
+            Amount::new(1_000),
+        ) else {
+            panic!("expected Ok");
+        };
+        assert_ne!(a, b);
+    }
+
+    // -- Debug ----------------------------------------------------------------
+
+    #[test]
+    fn debug_format_contains_struct_name() {
+        let cfg = valid_cfg();
+        let dbg = format!("{cfg:?}");
+        assert!(dbg.contains("HybridConfig"));
     }
 }


### PR DESCRIPTION
## Summary

Enhance `HybridConfig` with fee tier range validation, amplification upper bound enforcement, and a comprehensive test suite covering all validation paths.

## Changes

- **src/config/hybrid.rs**:
  - Added fee tier validation: reject fee tiers exceeding 10 000 basis points (100%) via `BasisPoints::is_valid_percent()`, returning `AmmError::InvalidFee`
  - Added amplification upper bound: must be in range `1..=10_000`, returning `AmmError::InvalidConfiguration`. Defined as `const MAX_AMPLIFICATION: u32 = 10_000`.
  - Validation order: fee tier → amplification range → reserve_a non-zero → reserve_b non-zero
  - Updated `///` docs on struct, `new()`, and `validate()` to document all error variants
  - Comprehensive test suite (22 tests total):
    - **Valid construction**: default config, amplification 1/max (10000)/typical stablecoin values (50–5000), standard fee tiers, zero/max fee, large (`u128::MAX`) and minimum reserves
    - **Fee validation**: 10001 bps rejected, `u32::MAX` rejected
    - **Amplification validation**: zero rejected, 10001 rejected, `u32::MAX` rejected
    - **Reserve validation**: zero reserve_a, zero reserve_b, both zero, error variant matching
    - **validate()** on existing valid instance
    - **Accessors** correctness
    - **Clone** equality, **PartialEq** inequality
    - **Debug** format verification

## Technical Decisions

- **`MAX_AMPLIFICATION` as associated constant**: Defined as `const MAX_AMPLIFICATION: u32 = 10_000` on the impl block rather than a module-level constant, keeping it scoped to the struct. The value 10 000 matches the issue spec and covers all practical StableSwap deployments (Curve typically uses 50–5000).
- **Single combined check**: `amplification == 0 || amplification > MAX_AMPLIFICATION` covers both bounds in one branch, using `AmmError::InvalidConfiguration` with a descriptive message including the valid range.

## Testing

- [x] Unit tests added (22 tests covering all validation paths)
- [x] Manual testing performed (`make lint-fix` + `make pre-push` — all tests passed, zero warnings)

## Checklist

- [x] Code follows `.internalDoc/09-RUST-GUIDELINES.md`
- [x] All public items have `///` documentation
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] Feature-gated code compiles with and without its feature
- [x] No `.unwrap()`, `.expect()`, or panics in library code

Closes #20