### PR TITLE
M5 #21: Implement WeightedConfig with weight sum validation

### DIFF
--- a/src/config/weighted.rs
+++ b/src/config/weighted.rs
@@ -17,9 +17,11 @@ use crate::error::AmmError;
 ///
 /// # Validation
 ///
+/// - Fee tier must be a valid percentage (0–10 000 basis points).
 /// - `tokens.len() == weights.len() == balances.len()`
 /// - At least 2 tokens.
 /// - No duplicate token addresses.
+/// - All individual weights must be greater than zero.
 /// - Weights must sum to exactly 10 000 basis points.
 /// - All balances must be non-zero.
 #[derive(Debug, Clone, PartialEq)]
@@ -43,9 +45,11 @@ impl WeightedConfig {
     ///
     /// # Errors
     ///
+    /// - [`AmmError::InvalidFee`] if the fee tier exceeds 100% (10 000 basis points).
     /// - [`AmmError::InvalidConfiguration`] if vector lengths differ, or
     ///   fewer than 2 tokens, or duplicate token addresses, or weights do
     ///   not sum to 10 000.
+    /// - [`AmmError::InvalidWeight`] if any individual weight is zero.
     /// - [`AmmError::ZeroReserve`] if any balance is zero.
     pub fn new(
         tokens: Vec<Token>,
@@ -67,11 +71,18 @@ impl WeightedConfig {
     ///
     /// # Errors
     ///
+    /// - [`AmmError::InvalidFee`] if the fee tier exceeds 100% (10 000 basis points).
     /// - [`AmmError::InvalidConfiguration`] if vector lengths differ, or
     ///   fewer than 2 tokens, or duplicate token addresses, or weights do
     ///   not sum to 10 000.
+    /// - [`AmmError::InvalidWeight`] if any individual weight is zero.
     /// - [`AmmError::ZeroReserve`] if any balance is zero.
     pub fn validate(&self) -> Result<(), AmmError> {
+        if !self.fee_tier.basis_points().is_valid_percent() {
+            return Err(AmmError::InvalidFee(
+                "fee tier must not exceed 10000 basis points (100%)",
+            ));
+        }
         if self.tokens.len() != self.weights.len() || self.tokens.len() != self.balances.len() {
             return Err(AmmError::InvalidConfiguration(
                 "tokens, weights, and balances must have equal length",
@@ -92,6 +103,14 @@ impl WeightedConfig {
                         "duplicate token addresses are not allowed",
                     ));
                 }
+            }
+        }
+
+        for w in &self.weights {
+            if w.get() == 0 {
+                return Err(AmmError::InvalidWeight(
+                    "all individual weights must be greater than zero",
+                ));
             }
         }
 
@@ -142,6 +161,8 @@ mod tests {
     use super::*;
     use crate::domain::{Decimals, TokenAddress};
 
+    // -- helpers --------------------------------------------------------------
+
     fn tok(byte: u8, dec: u8) -> Token {
         let Ok(d) = Decimals::new(dec) else {
             panic!("valid decimals");
@@ -156,6 +177,20 @@ mod tests {
     fn bps(v: u32) -> BasisPoints {
         BasisPoints::new(v)
     }
+
+    fn valid_cfg() -> WeightedConfig {
+        let Ok(cfg) = WeightedConfig::new(
+            vec![tok(1, 6), tok(2, 18)],
+            vec![bps(5_000), bps(5_000)],
+            fee(),
+            vec![Amount::new(1_000), Amount::new(2_000)],
+        ) else {
+            panic!("expected Ok");
+        };
+        cfg
+    }
+
+    // -- valid construction ---------------------------------------------------
 
     #[test]
     fn valid_two_token_pool() {
@@ -180,6 +215,122 @@ mod tests {
     }
 
     #[test]
+    fn valid_asymmetric_weights() {
+        let result = WeightedConfig::new(
+            vec![tok(1, 6), tok(2, 18)],
+            vec![bps(8_000), bps(2_000)],
+            fee(),
+            vec![Amount::new(1_000), Amount::new(500)],
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn valid_with_standard_fee_tiers() {
+        for tier in [
+            FeeTier::TIER_0_01_PERCENT,
+            FeeTier::TIER_0_05_PERCENT,
+            FeeTier::TIER_0_30_PERCENT,
+            FeeTier::TIER_1_00_PERCENT,
+        ] {
+            let result = WeightedConfig::new(
+                vec![tok(1, 6), tok(2, 18)],
+                vec![bps(5_000), bps(5_000)],
+                tier,
+                vec![Amount::new(1_000), Amount::new(1_000)],
+            );
+            assert!(result.is_ok());
+        }
+    }
+
+    #[test]
+    fn valid_with_zero_fee() {
+        let zero_fee = FeeTier::new(BasisPoints::new(0));
+        let result = WeightedConfig::new(
+            vec![tok(1, 6), tok(2, 18)],
+            vec![bps(5_000), bps(5_000)],
+            zero_fee,
+            vec![Amount::new(1), Amount::new(1)],
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn valid_with_max_valid_fee() {
+        let max_fee = FeeTier::new(BasisPoints::new(10_000));
+        let result = WeightedConfig::new(
+            vec![tok(1, 6), tok(2, 18)],
+            vec![bps(5_000), bps(5_000)],
+            max_fee,
+            vec![Amount::new(1), Amount::new(1)],
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn valid_with_large_balances() {
+        let result = WeightedConfig::new(
+            vec![tok(1, 6), tok(2, 18)],
+            vec![bps(5_000), bps(5_000)],
+            fee(),
+            vec![Amount::new(u128::MAX), Amount::new(u128::MAX)],
+        );
+        assert!(result.is_ok());
+    }
+
+    // -- fee_tier validation --------------------------------------------------
+
+    #[test]
+    fn fee_exceeding_100_percent_rejected() {
+        let bad_fee = FeeTier::new(BasisPoints::new(10_001));
+        let result = WeightedConfig::new(
+            vec![tok(1, 6), tok(2, 18)],
+            vec![bps(5_000), bps(5_000)],
+            bad_fee,
+            vec![Amount::new(1_000), Amount::new(1_000)],
+        );
+        assert!(matches!(result, Err(AmmError::InvalidFee(_))));
+    }
+
+    #[test]
+    fn fee_way_above_range_rejected() {
+        let bad_fee = FeeTier::new(BasisPoints::new(u32::MAX));
+        let result = WeightedConfig::new(
+            vec![tok(1, 6), tok(2, 18)],
+            vec![bps(5_000), bps(5_000)],
+            bad_fee,
+            vec![Amount::new(1_000), Amount::new(1_000)],
+        );
+        assert!(matches!(result, Err(AmmError::InvalidFee(_))));
+    }
+
+    // -- length validation ----------------------------------------------------
+
+    #[test]
+    fn mismatched_weights_length_rejected() {
+        let result = WeightedConfig::new(
+            vec![tok(1, 6), tok(2, 18)],
+            vec![bps(5_000)],
+            fee(),
+            vec![Amount::new(1_000), Amount::new(2_000)],
+        );
+        assert!(matches!(result, Err(AmmError::InvalidConfiguration(_))));
+    }
+
+    #[test]
+    fn mismatched_balances_length_rejected() {
+        let result = WeightedConfig::new(
+            vec![tok(1, 6), tok(2, 18)],
+            vec![bps(5_000), bps(5_000)],
+            fee(),
+            vec![Amount::new(1_000)],
+        );
+        assert!(matches!(result, Err(AmmError::InvalidConfiguration(_))));
+    }
+
+    // -- min tokens -----------------------------------------------------------
+
+    #[test]
     fn fewer_than_two_tokens_rejected() {
         let result = WeightedConfig::new(
             vec![tok(1, 6)],
@@ -187,19 +338,16 @@ mod tests {
             fee(),
             vec![Amount::new(1_000)],
         );
-        assert!(result.is_err());
+        assert!(matches!(result, Err(AmmError::InvalidConfiguration(_))));
     }
 
     #[test]
-    fn mismatched_lengths_rejected() {
-        let result = WeightedConfig::new(
-            vec![tok(1, 6), tok(2, 18)],
-            vec![bps(5_000)],
-            fee(),
-            vec![Amount::new(1_000), Amount::new(2_000)],
-        );
-        assert!(result.is_err());
+    fn empty_tokens_rejected() {
+        let result = WeightedConfig::new(vec![], vec![], fee(), vec![]);
+        assert!(matches!(result, Err(AmmError::InvalidConfiguration(_))));
     }
+
+    // -- duplicate tokens -----------------------------------------------------
 
     #[test]
     fn duplicate_tokens_rejected() {
@@ -209,8 +357,34 @@ mod tests {
             fee(),
             vec![Amount::new(1_000), Amount::new(2_000)],
         );
-        assert!(result.is_err());
+        assert!(matches!(result, Err(AmmError::InvalidConfiguration(_))));
     }
+
+    // -- individual weight validation -----------------------------------------
+
+    #[test]
+    fn zero_weight_rejected() {
+        let result = WeightedConfig::new(
+            vec![tok(1, 6), tok(2, 18)],
+            vec![bps(0), bps(10_000)],
+            fee(),
+            vec![Amount::new(1_000), Amount::new(1_000)],
+        );
+        assert!(matches!(result, Err(AmmError::InvalidWeight(_))));
+    }
+
+    #[test]
+    fn second_weight_zero_rejected() {
+        let result = WeightedConfig::new(
+            vec![tok(1, 6), tok(2, 18)],
+            vec![bps(10_000), bps(0)],
+            fee(),
+            vec![Amount::new(1_000), Amount::new(1_000)],
+        );
+        assert!(matches!(result, Err(AmmError::InvalidWeight(_))));
+    }
+
+    // -- weight sum validation ------------------------------------------------
 
     #[test]
     fn weights_not_summing_to_10000_rejected() {
@@ -220,19 +394,53 @@ mod tests {
             fee(),
             vec![Amount::new(1_000), Amount::new(2_000)],
         );
-        assert!(result.is_err());
+        assert!(matches!(result, Err(AmmError::InvalidConfiguration(_))));
     }
 
     #[test]
-    fn zero_balance_rejected() {
+    fn weights_exceeding_10000_rejected() {
+        let result = WeightedConfig::new(
+            vec![tok(1, 6), tok(2, 18)],
+            vec![bps(6_000), bps(6_000)],
+            fee(),
+            vec![Amount::new(1_000), Amount::new(1_000)],
+        );
+        assert!(matches!(result, Err(AmmError::InvalidConfiguration(_))));
+    }
+
+    // -- balance validation ---------------------------------------------------
+
+    #[test]
+    fn zero_balance_first_rejected() {
+        let result = WeightedConfig::new(
+            vec![tok(1, 6), tok(2, 18)],
+            vec![bps(5_000), bps(5_000)],
+            fee(),
+            vec![Amount::ZERO, Amount::new(1_000)],
+        );
+        assert!(matches!(result, Err(AmmError::ZeroReserve)));
+    }
+
+    #[test]
+    fn zero_balance_second_rejected() {
         let result = WeightedConfig::new(
             vec![tok(1, 6), tok(2, 18)],
             vec![bps(5_000), bps(5_000)],
             fee(),
             vec![Amount::new(1_000), Amount::ZERO],
         );
-        assert!(result.is_err());
+        assert!(matches!(result, Err(AmmError::ZeroReserve)));
     }
+
+    // -- validate on existing instance ----------------------------------------
+
+    #[test]
+    fn validate_on_valid_config_succeeds() {
+        let cfg = valid_cfg();
+        assert!(cfg.validate().is_ok());
+    }
+
+    // -- accessors ------------------------------------------------------------
 
     #[test]
     fn accessors() {
@@ -246,7 +454,50 @@ mod tests {
         };
         assert_eq!(cfg.tokens().len(), 2);
         assert_eq!(cfg.weights().len(), 2);
+        assert_eq!(cfg.weights()[0], bps(5_000));
+        assert_eq!(cfg.weights()[1], bps(5_000));
         assert_eq!(cfg.balances().len(), 2);
+        assert_eq!(cfg.balances()[0], Amount::new(100));
+        assert_eq!(cfg.balances()[1], Amount::new(200));
         assert_eq!(cfg.fee_tier(), fee());
+    }
+
+    // -- Clone & PartialEq ---------------------------------------------------
+
+    #[test]
+    fn clone_equality() {
+        let cfg = valid_cfg();
+        let cloned = cfg.clone();
+        assert_eq!(cfg, cloned);
+    }
+
+    #[test]
+    fn different_weights_not_equal() {
+        let Ok(a) = WeightedConfig::new(
+            vec![tok(1, 6), tok(2, 18)],
+            vec![bps(5_000), bps(5_000)],
+            fee(),
+            vec![Amount::new(1_000), Amount::new(1_000)],
+        ) else {
+            panic!("expected Ok");
+        };
+        let Ok(b) = WeightedConfig::new(
+            vec![tok(1, 6), tok(2, 18)],
+            vec![bps(8_000), bps(2_000)],
+            fee(),
+            vec![Amount::new(1_000), Amount::new(1_000)],
+        ) else {
+            panic!("expected Ok");
+        };
+        assert_ne!(a, b);
+    }
+
+    // -- Debug ----------------------------------------------------------------
+
+    #[test]
+    fn debug_format_contains_struct_name() {
+        let cfg = valid_cfg();
+        let dbg = format!("{cfg:?}");
+        assert!(dbg.contains("WeightedConfig"));
     }
 }


### PR DESCRIPTION
## Summary

Enhance `WeightedConfig` with fee tier range validation, individual zero-weight rejection, and a comprehensive test suite covering all validation paths.

## Changes

- **src/config/weighted.rs**:
  - Added fee tier validation: reject fee tiers exceeding 10 000 basis points (100%) via `BasisPoints::is_valid_percent()`, returning `AmmError::InvalidFee`
  - Added individual weight > 0 validation: reject any zero-weight token with `AmmError::InvalidWeight`, checked before the weight sum to give more precise diagnostics
  - Validation order: fee tier → length mismatch → min tokens (≥2) → duplicate addresses → individual weights > 0 → weight sum == 10 000 → non-zero balances
  - Updated `///` docs on struct, `new()`, and `validate()` to document all error variants
  - Comprehensive test suite (27 tests total):
    - **Valid construction**: 2-token, 3-token, asymmetric weights (80/20), standard fee tiers, zero/max fee, large balances (`u128::MAX`)
    - **Fee validation**: 10001 bps rejected, `u32::MAX` rejected
    - **Length validation**: mismatched weights length, mismatched balances length
    - **Min tokens**: 1 token rejected, empty vecs rejected
    - **Duplicate tokens**: same address rejected
    - **Individual weight**: first weight zero rejected, second weight zero rejected
    - **Weight sum**: under 10 000 rejected, over 10 000 rejected
    - **Balance**: first zero, second zero
    - **validate()** on existing valid instance
    - **Accessors** with value checks
    - **Clone** equality, **PartialEq** inequality
    - **Debug** format verification

## Technical Decisions

- **`AmmError::InvalidWeight`** for zero-weight: Used the domain-specific error variant rather than `InvalidConfiguration` to distinguish between structural config errors (length/count/sum) and per-token weight errors. This gives more actionable diagnostics.
- **Check order**: Individual weight > 0 is checked after duplicate detection but before the sum check. This way, a zero-weight token is reported as a weight error rather than a sum error.

## Testing

- [x] Unit tests added (27 tests covering all validation paths)
- [x] Manual testing performed (`make lint-fix` + `make pre-push` — all tests passed, zero warnings)

## Checklist

- [x] Code follows `.internalDoc/09-RUST-GUIDELINES.md`
- [x] All public items have `///` documentation
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] Feature-gated code compiles with and without its feature
- [x] No `.unwrap()`, `.expect()`, or panics in library code

Closes #21