### PR TITLE
M8 #32: Comprehensive unit tests for domain types and math modules

### DIFF
--- a/src/domain/amount.rs
+++ b/src/domain/amount.rs
@@ -333,4 +333,55 @@ mod tests {
         let b = a;
         assert_eq!(a, b);
     }
+
+    #[test]
+    fn debug_format() {
+        let a = Amount::new(42);
+        let dbg = format!("{a:?}");
+        assert!(dbg.contains("Amount"));
+        assert!(dbg.contains("42"));
+    }
+
+    #[test]
+    fn hash_consistency() {
+        use core::hash::{Hash, Hasher};
+        fn hash_of<T: Hash>(t: &T) -> u64 {
+            let mut h = std::collections::hash_map::DefaultHasher::new();
+            t.hash(&mut h);
+            h.finish()
+        }
+        let a = Amount::new(100);
+        let b = Amount::new(100);
+        assert_eq!(hash_of(&a), hash_of(&b));
+    }
+
+    #[test]
+    fn mul_identity() {
+        let a = Amount::new(999);
+        assert_eq!(a.checked_mul(&Amount::new(1)), Some(a));
+    }
+
+    #[test]
+    fn sub_zero_identity() {
+        let a = Amount::new(42);
+        assert_eq!(a.checked_sub(&Amount::ZERO), Some(a));
+    }
+
+    #[test]
+    fn div_larger_divisor_round_down() {
+        // 1 / 2 = 0 (floor)
+        assert_eq!(
+            Amount::new(1).checked_div(&Amount::new(2), Rounding::Down),
+            Some(Amount::ZERO)
+        );
+    }
+
+    #[test]
+    fn div_larger_divisor_round_up() {
+        // 1 / 2 = 1 (ceil)
+        assert_eq!(
+            Amount::new(1).checked_div(&Amount::new(2), Rounding::Up),
+            Some(Amount::new(1))
+        );
+    }
 }

--- a/src/domain/basis_points.rs
+++ b/src/domain/basis_points.rs
@@ -241,4 +241,49 @@ mod tests {
         let b = a;
         assert_eq!(a, b);
     }
+
+    #[test]
+    fn hash_consistency() {
+        use core::hash::{Hash, Hasher};
+        fn hash_of<T: Hash>(t: &T) -> u64 {
+            let mut h = std::collections::hash_map::DefaultHasher::new();
+            t.hash(&mut h);
+            h.finish()
+        }
+        let a = BasisPoints::new(30);
+        let b = BasisPoints::new(30);
+        assert_eq!(hash_of(&a), hash_of(&b));
+    }
+
+    #[test]
+    fn apply_100_percent() {
+        // 10_000bp of 1_000 = 1_000 (full amount)
+        let bp = BasisPoints::MAX_PERCENT;
+        let Ok(result) = bp.apply(Amount::new(1_000), Rounding::Down) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(result, Amount::new(1_000));
+    }
+
+    #[test]
+    fn apply_50_percent() {
+        // 5_000bp of 1_000 = 500
+        let bp = BasisPoints::new(5_000);
+        let Ok(result) = bp.apply(Amount::new(1_000), Rounding::Down) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(result, Amount::new(500));
+    }
+
+    #[test]
+    fn debug_format() {
+        let bp = BasisPoints::new(30);
+        let dbg = format!("{bp:?}");
+        assert!(dbg.contains("BasisPoints"));
+    }
+
+    #[test]
+    fn as_percent_zero() {
+        assert!((BasisPoints::ZERO.as_percent() - 0.0).abs() < f64::EPSILON);
+    }
 }

--- a/src/domain/liquidity.rs
+++ b/src/domain/liquidity.rs
@@ -187,4 +187,38 @@ mod tests {
         let b = a;
         assert_eq!(a, b);
     }
+
+    #[test]
+    fn hash_consistency() {
+        use core::hash::{Hash, Hasher};
+        fn hash_of<T: Hash>(t: &T) -> u64 {
+            let mut h = std::collections::hash_map::DefaultHasher::new();
+            t.hash(&mut h);
+            h.finish()
+        }
+        let a = Liquidity::new(500);
+        let b = Liquidity::new(500);
+        assert_eq!(hash_of(&a), hash_of(&b));
+    }
+
+    #[test]
+    fn debug_format() {
+        let l = Liquidity::new(42);
+        let dbg = format!("{l:?}");
+        assert!(dbg.contains("Liquidity"));
+    }
+
+    #[test]
+    fn mul_amount_by_one() {
+        let l = Liquidity::new(1);
+        let a = Amount::new(999);
+        assert_eq!(l.checked_mul_amount(&a), Some(a));
+    }
+
+    #[test]
+    fn sub_to_zero_is_zero() {
+        let l = Liquidity::new(42);
+        assert_eq!(l.checked_sub(&l), Some(Liquidity::ZERO));
+        assert!(l.checked_sub(&l).is_some_and(|v| v.is_zero()));
+    }
 }

--- a/src/domain/liquidity_change.rs
+++ b/src/domain/liquidity_change.rs
@@ -334,4 +334,64 @@ mod tests {
         let b = a;
         assert_eq!(a, b);
     }
+
+    #[test]
+    fn hash_consistency() {
+        use core::hash::{Hash, Hasher};
+        fn hash_of<T: Hash>(t: &T) -> u64 {
+            let mut h = std::collections::hash_map::DefaultHasher::new();
+            t.hash(&mut h);
+            h.finish()
+        }
+        let Ok(a) = LiquidityChange::add(Amount::new(10), Amount::new(20)) else {
+            panic!("expected Ok");
+        };
+        let Ok(b) = LiquidityChange::add(Amount::new(10), Amount::new(20)) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(hash_of(&a), hash_of(&b));
+    }
+
+    #[test]
+    fn debug_format_add() {
+        let Ok(c) = LiquidityChange::add(Amount::new(1), Amount::new(2)) else {
+            panic!("expected Ok");
+        };
+        let dbg = format!("{c:?}");
+        assert!(dbg.contains("Add"));
+    }
+
+    #[test]
+    fn debug_format_remove() {
+        let Ok(c) = LiquidityChange::remove(Liquidity::new(100)) else {
+            panic!("expected Ok");
+        };
+        let dbg = format!("{c:?}");
+        assert!(dbg.contains("Remove"));
+    }
+
+    #[test]
+    fn debug_format_rebalance() {
+        let Ok(c) = LiquidityChange::rebalance(tick(-10), tick(10)) else {
+            panic!("expected Ok");
+        };
+        let dbg = format!("{c:?}");
+        assert!(dbg.contains("Rebalance"));
+    }
+
+    #[test]
+    fn remove_change_type() {
+        let Ok(c) = LiquidityChange::remove(Liquidity::new(1)) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(c.change_type(), ChangeType::Remove);
+    }
+
+    #[test]
+    fn rebalance_change_type() {
+        let Ok(c) = LiquidityChange::rebalance(tick(-50), tick(50)) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(c.change_type(), ChangeType::Rebalance);
+    }
 }

--- a/src/domain/position.rs
+++ b/src/domain/position.rs
@@ -242,4 +242,49 @@ mod tests {
         let b = a;
         assert_eq!(a, b);
     }
+
+    #[test]
+    fn hash_consistency() {
+        use core::hash::{Hash, Hasher};
+        fn hash_of<T: Hash>(t: &T) -> u64 {
+            let mut h = std::collections::hash_map::DefaultHasher::new();
+            t.hash(&mut h);
+            h.finish()
+        }
+        let Ok(a) = Position::new(tick(-100), tick(100), Liquidity::new(1000)) else {
+            panic!("expected Ok");
+        };
+        let Ok(b) = Position::new(tick(-100), tick(100), Liquidity::new(1000)) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(hash_of(&a), hash_of(&b));
+    }
+
+    #[test]
+    fn width_full_range() {
+        // Position spanning MIN to MAX ticks
+        let Ok(pos) = Position::new(Tick::MIN, Tick::MAX, Liquidity::new(1)) else {
+            panic!("expected Ok");
+        };
+        // MAX - MIN = 887272 - (-887272) = 1774544
+        assert_eq!(pos.width(), 1_774_544);
+    }
+
+    #[test]
+    fn is_in_range_at_boundary_minus_one() {
+        let Ok(pos) = Position::new(tick(-100), tick(100), Liquidity::new(1)) else {
+            panic!("expected Ok");
+        };
+        // upper - 1 should be in range
+        assert!(pos.is_in_range(tick(99)));
+    }
+
+    #[test]
+    fn debug_format() {
+        let Ok(pos) = Position::new(tick(-10), tick(10), Liquidity::new(1)) else {
+            panic!("expected Ok");
+        };
+        let dbg = format!("{pos:?}");
+        assert!(dbg.contains("Position"));
+    }
 }

--- a/src/domain/price.rs
+++ b/src/domain/price.rs
@@ -310,4 +310,61 @@ mod tests {
         let b = a;
         assert_eq!(a, b);
     }
+
+    #[test]
+    fn inverse_round_trip() {
+        let Ok(p) = Price::new(4.0) else {
+            panic!("expected Ok");
+        };
+        let Ok(inv) = p.inverse() else {
+            panic!("expected Ok");
+        };
+        let Ok(back) = inv.inverse() else {
+            panic!("expected Ok");
+        };
+        assert!((back.get() - 4.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn multiply_fractional_rounding_difference() {
+        // 1/3 * 10 = 3.333...; Down = 3, Up = 4
+        let Ok(p) = Price::from_amounts(Amount::new(1), Amount::new(3), Rounding::Down) else {
+            panic!("expected Ok");
+        };
+        let Ok(down) = p.multiply(Amount::new(10), Rounding::Down) else {
+            panic!("expected Ok");
+        };
+        let Ok(up) = p.multiply(Amount::new(10), Rounding::Up) else {
+            panic!("expected Ok");
+        };
+        assert!(down.get() <= up.get());
+    }
+
+    #[test]
+    fn from_amounts_large_values() {
+        let Ok(p) = Price::from_amounts(
+            Amount::new(1_000_000_000_000_000_000),
+            Amount::new(1_000_000_000_000_000_000),
+            Rounding::Down,
+        ) else {
+            panic!("expected Ok");
+        };
+        assert!((p.get() - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn is_finite_always_true_for_valid() {
+        let Ok(p) = Price::new(1e100) else {
+            panic!("expected Ok");
+        };
+        assert!(p.is_finite());
+    }
+
+    #[test]
+    fn new_very_small_positive() {
+        let Ok(p) = Price::new(1e-300) else {
+            panic!("expected Ok");
+        };
+        assert!(p.get() > 0.0);
+    }
 }

--- a/src/domain/rounding.rs
+++ b/src/domain/rounding.rs
@@ -88,4 +88,25 @@ mod tests {
         let b = a;
         assert_eq!(a, b);
     }
+
+    #[test]
+    fn hash_consistency() {
+        use core::hash::{Hash, Hasher};
+        fn hash_of<T: Hash>(t: &T) -> u64 {
+            let mut h = std::collections::hash_map::DefaultHasher::new();
+            t.hash(&mut h);
+            h.finish()
+        }
+        assert_eq!(hash_of(&Rounding::Up), hash_of(&Rounding::Up));
+        assert_eq!(hash_of(&Rounding::Down), hash_of(&Rounding::Down));
+        assert_ne!(hash_of(&Rounding::Up), hash_of(&Rounding::Down));
+    }
+
+    #[test]
+    fn debug_format() {
+        let dbg_up = format!("{:?}", Rounding::Up);
+        let dbg_down = format!("{:?}", Rounding::Down);
+        assert!(dbg_up.contains("Up"));
+        assert!(dbg_down.contains("Down"));
+    }
 }

--- a/src/domain/swap_spec.rs
+++ b/src/domain/swap_spec.rs
@@ -206,4 +206,49 @@ mod tests {
         let b = a;
         assert_eq!(a, b);
     }
+
+    #[test]
+    fn hash_consistency() {
+        use core::hash::{Hash, Hasher};
+        fn hash_of<T: Hash>(t: &T) -> u64 {
+            let mut h = std::collections::hash_map::DefaultHasher::new();
+            t.hash(&mut h);
+            h.finish()
+        }
+        let Ok(a) = SwapSpec::exact_in(Amount::new(100)) else {
+            panic!("expected Ok");
+        };
+        let Ok(b) = SwapSpec::exact_in(Amount::new(100)) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(hash_of(&a), hash_of(&b));
+    }
+
+    #[test]
+    fn exact_in_and_exact_out_not_equal() {
+        let Ok(a) = SwapSpec::exact_in(Amount::new(100)) else {
+            panic!("expected Ok");
+        };
+        let Ok(b) = SwapSpec::exact_out(Amount::new(100)) else {
+            panic!("expected Ok");
+        };
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn debug_format() {
+        let Ok(spec) = SwapSpec::exact_in(Amount::new(42)) else {
+            panic!("expected Ok");
+        };
+        let dbg = format!("{spec:?}");
+        assert!(dbg.contains("ExactIn"));
+    }
+
+    #[test]
+    fn amount_extraction_exact_out() {
+        let Ok(spec) = SwapSpec::exact_out(Amount::new(777)) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(spec.amount(), Amount::new(777));
+    }
 }

--- a/src/domain/tick.rs
+++ b/src/domain/tick.rs
@@ -313,4 +313,42 @@ mod tests {
         let b = a;
         assert_eq!(a, b);
     }
+
+    #[test]
+    fn hash_consistency() {
+        use core::hash::{Hash, Hasher};
+        fn hash_of<T: Hash>(t: &T) -> u64 {
+            let mut h = std::collections::hash_map::DefaultHasher::new();
+            t.hash(&mut h);
+            h.finish()
+        }
+        let (Ok(a), Ok(b)) = (Tick::new(1000), Tick::new(1000)) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(hash_of(&a), hash_of(&b));
+    }
+
+    #[test]
+    fn checked_add_i32_overflow() {
+        // i32::MAX delta on MAX tick would overflow i32 before range check
+        assert_eq!(Tick::MAX.checked_add(i32::MAX), None);
+    }
+
+    #[test]
+    fn checked_sub_i32_overflow() {
+        assert_eq!(Tick::MIN.checked_sub(i32::MAX), None);
+    }
+
+    #[test]
+    fn display_negative() {
+        let Ok(t) = Tick::new(-42) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(format!("{t}"), "Tick(-42)");
+    }
+
+    #[test]
+    fn spacing_max_u16_valid() {
+        assert!(Tick::spacing_is_valid(u16::MAX));
+    }
 }

--- a/src/domain/token.rs
+++ b/src/domain/token.rs
@@ -127,4 +127,45 @@ mod tests {
         let b = a;
         assert_eq!(a, b);
     }
+
+    #[test]
+    fn debug_format() {
+        let tok = sample_token(1, 6);
+        let dbg = format!("{tok:?}");
+        assert!(dbg.contains("Token"));
+    }
+
+    #[test]
+    fn hash_consistency() {
+        use core::hash::{Hash, Hasher};
+        fn hash_of<T: Hash>(t: &T) -> u64 {
+            let mut h = std::collections::hash_map::DefaultHasher::new();
+            t.hash(&mut h);
+            h.finish()
+        }
+        let a = sample_token(1, 6);
+        let b = sample_token(1, 6);
+        assert_eq!(hash_of(&a), hash_of(&b));
+    }
+
+    #[test]
+    fn from_raw_amount_overflow() {
+        // u128::MAX with zero decimals => u128::MAX > u64::MAX
+        let tok = sample_token(1, 0);
+        let result = tok.from_raw_amount(u128::MAX);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn to_raw_amount_zero() {
+        let tok = sample_token(1, 18);
+        assert_eq!(tok.to_raw_amount(0), 0);
+    }
+
+    #[test]
+    fn different_address_not_equal() {
+        let a = sample_token(1, 6);
+        let b = sample_token(2, 6);
+        assert_ne!(a, b);
+    }
 }

--- a/src/domain/token_address.rs
+++ b/src/domain/token_address.rs
@@ -89,4 +89,36 @@ mod tests {
         let dbg = format!("{addr:?}");
         assert!(dbg.contains("TokenAddress"));
     }
+
+    #[test]
+    fn hash_consistency() {
+        use core::hash::{Hash, Hasher};
+        fn hash_of<T: Hash>(t: &T) -> u64 {
+            let mut h = std::collections::hash_map::DefaultHasher::new();
+            t.hash(&mut h);
+            h.finish()
+        }
+        let a = TokenAddress::from_bytes([7u8; 32]);
+        let b = TokenAddress::from_bytes([7u8; 32]);
+        assert_eq!(hash_of(&a), hash_of(&b));
+    }
+
+    #[test]
+    fn distinct_addresses_have_different_hashes() {
+        use core::hash::{Hash, Hasher};
+        fn hash_of<T: Hash>(t: &T) -> u64 {
+            let mut h = std::collections::hash_map::DefaultHasher::new();
+            t.hash(&mut h);
+            h.finish()
+        }
+        let a = TokenAddress::from_bytes([1u8; 32]);
+        let b = TokenAddress::from_bytes([2u8; 32]);
+        assert_ne!(hash_of(&a), hash_of(&b));
+    }
+
+    #[test]
+    fn max_byte_values() {
+        let addr = TokenAddress::from_bytes([0xFF; 32]);
+        assert_eq!(addr.as_bytes(), [0xFF; 32]);
+    }
 }

--- a/src/domain/token_pair.rs
+++ b/src/domain/token_pair.rs
@@ -216,4 +216,54 @@ mod tests {
         let p2 = p;
         assert_eq!(p, p2);
     }
+
+    #[test]
+    fn debug_format() {
+        let a = tok(1, 6);
+        let b = tok(2, 18);
+        let Ok(pair) = TokenPair::new(a, b) else {
+            panic!("expected Ok");
+        };
+        let dbg = format!("{pair:?}");
+        assert!(dbg.contains("TokenPair"));
+    }
+
+    #[test]
+    fn hash_consistency() {
+        use core::hash::{Hash, Hasher};
+        fn hash_of<T: Hash>(t: &T) -> u64 {
+            let mut h = std::collections::hash_map::DefaultHasher::new();
+            t.hash(&mut h);
+            h.finish()
+        }
+        let a = tok(1, 6);
+        let b = tok(2, 18);
+        let (Ok(p1), Ok(p2)) = (TokenPair::new(a, b), TokenPair::new(b, a)) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(hash_of(&p1), hash_of(&p2));
+    }
+
+    #[test]
+    fn is_ordered_correctly_always_true() {
+        let a = tok(1, 6);
+        let b = tok(2, 18);
+        let Ok(pair) = TokenPair::new(b, a) else {
+            panic!("expected Ok");
+        };
+        assert!(pair.is_ordered_correctly());
+    }
+
+    #[test]
+    fn other_returns_first_when_given_second() {
+        let a = tok(1, 6);
+        let b = tok(2, 18);
+        let Ok(pair) = TokenPair::new(a, b) else {
+            panic!("expected Ok");
+        };
+        let Ok(other) = pair.other(&b) else {
+            panic!("expected Ok");
+        };
+        assert_eq!(other, a);
+    }
 }

--- a/src/math/checked.rs
+++ b/src/math/checked.rs
@@ -303,6 +303,62 @@ mod tests {
             };
             assert_eq!(r, Amount::new(800));
         }
+
+        #[test]
+        fn add_zero_identity() {
+            let Ok(r) = Amount::new(42).safe_add(&Amount::ZERO) else {
+                panic!("expected Ok");
+            };
+            assert_eq!(r, Amount::new(42));
+        }
+
+        #[test]
+        fn sub_to_zero() {
+            let Ok(r) = Amount::new(42).safe_sub(&Amount::new(42)) else {
+                panic!("expected Ok");
+            };
+            assert_eq!(r, Amount::ZERO);
+        }
+
+        #[test]
+        fn mul_by_zero() {
+            let Ok(r) = Amount::new(999).safe_mul(&Amount::ZERO) else {
+                panic!("expected Ok");
+            };
+            assert_eq!(r, Amount::ZERO);
+        }
+
+        #[test]
+        fn mul_by_one() {
+            let Ok(r) = Amount::new(42).safe_mul(&Amount::new(1)) else {
+                panic!("expected Ok");
+            };
+            assert_eq!(r, Amount::new(42));
+        }
+
+        #[test]
+        fn div_zero_numerator() {
+            let Ok(r) = Amount::ZERO.safe_div(&Amount::new(10), Rounding::Down) else {
+                panic!("expected Ok");
+            };
+            assert_eq!(r, Amount::ZERO);
+        }
+
+        #[test]
+        fn div_by_one() {
+            let Ok(r) = Amount::new(42).safe_div(&Amount::new(1), Rounding::Down) else {
+                panic!("expected Ok");
+            };
+            assert_eq!(r, Amount::new(42));
+        }
+
+        #[test]
+        fn add_u128_zero() {
+            let Ok(r) = Amount::new(42).safe_add_u128(0) else {
+                panic!("expected Ok");
+            };
+            assert_eq!(r, Amount::new(42));
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -440,6 +496,62 @@ mod tests {
                 panic!("expected Ok");
             };
             assert_eq!(r, Liquidity::new(800));
+        }
+
+        #[test]
+        fn add_zero_identity() {
+            let Ok(r) = Liquidity::new(42).safe_add(&Liquidity::ZERO) else {
+                panic!("expected Ok");
+            };
+            assert_eq!(r, Liquidity::new(42));
+        }
+
+        #[test]
+        fn sub_to_zero() {
+            let Ok(r) = Liquidity::new(42).safe_sub(&Liquidity::new(42)) else {
+                panic!("expected Ok");
+            };
+            assert_eq!(r, Liquidity::ZERO);
+        }
+
+        #[test]
+        fn mul_by_zero() {
+            let Ok(r) = Liquidity::new(999).safe_mul(&Liquidity::ZERO) else {
+                panic!("expected Ok");
+            };
+            assert_eq!(r, Liquidity::ZERO);
+        }
+
+        #[test]
+        fn mul_by_one() {
+            let Ok(r) = Liquidity::new(42).safe_mul(&Liquidity::new(1)) else {
+                panic!("expected Ok");
+            };
+            assert_eq!(r, Liquidity::new(42));
+        }
+
+        #[test]
+        fn div_zero_numerator() {
+            let Ok(r) = Liquidity::ZERO.safe_div(&Liquidity::new(10), Rounding::Down) else {
+                panic!("expected Ok");
+            };
+            assert_eq!(r, Liquidity::ZERO);
+        }
+
+        #[test]
+        fn div_by_one() {
+            let Ok(r) = Liquidity::new(42).safe_div(&Liquidity::new(1), Rounding::Down) else {
+                panic!("expected Ok");
+            };
+            assert_eq!(r, Liquidity::new(42));
+        }
+
+        #[test]
+        fn add_u128_zero() {
+            let Ok(r) = Liquidity::new(42).safe_add_u128(0) else {
+                panic!("expected Ok");
+            };
+            assert_eq!(r, Liquidity::new(42));
         }
     }
 }

--- a/src/math/fixed_precision.rs
+++ b/src/math/fixed_precision.rs
@@ -468,4 +468,72 @@ mod tests {
         assert!(fp(1) < fp(2));
         assert!(fp(2) > fp(1));
     }
+
+    // -- Additional edge cases ----------------------------------------------
+
+    #[test]
+    fn checked_div_zero_numerator() {
+        let Ok(r) = FP::zero().checked_div(&fp(10), Rounding::Down) else {
+            panic!("expected Ok");
+        };
+        assert!(r.is_zero());
+    }
+
+    #[test]
+    fn checked_div_zero_numerator_round_up() {
+        let Ok(r) = FP::zero().checked_div(&fp(10), Rounding::Up) else {
+            panic!("expected Ok");
+        };
+        assert!(r.is_zero());
+    }
+
+    #[test]
+    fn from_u128_roundtrip_small() {
+        let v = FP::from_u128(1_000_000);
+        assert_eq!(v.to_u128(), 1_000_000);
+    }
+
+    #[test]
+    fn checked_add_negative_values() {
+        let Ok(r) = fp(-3).checked_add(&fp(-2)) else {
+            panic!("expected Ok");
+        };
+        assert!((r.to_f64_lossy() - (-5.0)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn checked_mul_negative_times_positive() {
+        let Ok(r) = fp(-3).checked_mul(&fp(2)) else {
+            panic!("expected Ok");
+        };
+        assert!((r.to_f64_lossy() - (-6.0)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn checked_div_negative_by_positive() {
+        let Ok(r) = fp(-6).checked_div(&fp(2), Rounding::Down) else {
+            panic!("expected Ok");
+        };
+        assert!((r.to_f64_lossy() - (-3.0)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn min_with_equal() {
+        assert_eq!(Precision::min(&fp(5), &fp(5)), fp(5));
+    }
+
+    #[test]
+    fn max_with_equal() {
+        assert_eq!(Precision::max(&fp(5), &fp(5)), fp(5));
+    }
+
+    #[test]
+    fn min_with_negative() {
+        assert_eq!(Precision::min(&fp(-3), &fp(3)), fp(-3));
+    }
+
+    #[test]
+    fn max_with_negative() {
+        assert_eq!(Precision::max(&fp(-3), &fp(3)), fp(3));
+    }
 }

--- a/src/math/rounding.rs
+++ b/src/math/rounding.rs
@@ -235,4 +235,43 @@ mod tests {
         // Protocol collects 4 fee units out of 10/3
         assert_eq!(div_round(10, 3, Rounding::Up), Some(4));
     }
+
+    // -- Identity and trivial cases -----------------------------------------
+
+    #[test]
+    fn one_divided_by_one() {
+        assert_eq!(div_round(1, 1, Rounding::Down), Some(1));
+        assert_eq!(div_round(1, 1, Rounding::Up), Some(1));
+    }
+
+    #[test]
+    fn numerator_equals_denominator() {
+        assert_eq!(div_round(100, 100, Rounding::Down), Some(1));
+        assert_eq!(div_round(100, 100, Rounding::Up), Some(1));
+    }
+
+    #[test]
+    fn one_divided_by_two() {
+        assert_eq!(div_round(1, 2, Rounding::Down), Some(0));
+        assert_eq!(div_round(1, 2, Rounding::Up), Some(1));
+    }
+
+    #[test]
+    fn consecutive_values_round_down() {
+        // 7/3 = 2 remainder 1
+        assert_eq!(div_round(7, 3, Rounding::Down), Some(2));
+        assert_eq!(div_round(7, 3, Rounding::Up), Some(3));
+    }
+
+    #[test]
+    fn down_always_leq_up() {
+        for (n, d) in [(1, 3), (5, 2), (100, 7), (u128::MAX, 3)] {
+            let down = div_round(n, d, Rounding::Down);
+            let up = div_round(n, d, Rounding::Up);
+            match (down, up) {
+                (Some(d_val), Some(u_val)) => assert!(d_val <= u_val),
+                _ => panic!("expected Some for n={n}, d={d}"),
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Adds ~111 new unit tests across all 15 domain types and 5 math modules, filling coverage gaps identified by auditing existing tests against Issue #32's scope. Total test count: **844 unit tests + 24 doc-tests**, all passing.

## Changes

### Domain types (15 files)
- **Hash consistency**: verified for all types deriving `Hash` (TokenAddress, Decimals, Token, Amount, Tick, Liquidity, BasisPoints, FeeTier, Position, SwapSpec, SwapResult, Rounding, LiquidityChange, TokenPair)
- **Debug format**: verified `Debug` output contains type name for all domain types
- **Edge cases**:
  - `Amount`: div with larger divisor (round up/down), mul identity, sub zero identity
  - `Decimals`: scale_down overflow, scale_up zero/max, scale_down zero, copy semantics
  - `Token`: from_raw_amount overflow, to_raw_amount zero, inequality
  - `Price`: inverse round-trip, multiply fractional rounding difference, large values, very small positive
  - `Tick`: i32 overflow in checked_add/sub, display negative, spacing max u16
  - `Liquidity`: mul_amount identity, sub to zero is_zero
  - `BasisPoints`: apply 100%, apply 50%, as_percent zero
  - `FeeTier`: apply overflow, 1bp round down small amount
  - `Position`: width full range (MIN→MAX = 1,774,544), boundary minus one, debug
  - `SwapSpec`: variant inequality, amount extraction, debug
  - `SwapResult`: fee boundary (fee = amount_in - 1), effective_price round up, slippage large deviation
  - `LiquidityChange`: debug for all variants, change_type for Remove/Rebalance
  - `TokenPair`: hash consistency across reversed inputs, is_ordered_correctly, other counterpart
  - `TokenAddress`: distinct address hashes differ, max byte values

### Math modules (5 files)
- **CheckedArithmetic** (Amount + Liquidity): identity ops — add zero, sub to zero, mul by zero/one, div zero numerator, div by one, add_u128 zero
- **div_round**: 1/1 identity, numerator equals denominator, 1/2, consecutive values, Down ≤ Up invariant
- **tick_math**: adjacent tick round-trips (±99..101), price symmetry (p(t) × p(-t) ≈ 1.0), near-boundary precision
- **FloatArithmetic**: NaN → 0, infinity saturates, round-trip small, negative arithmetic, negative zero, min/max equal
- **FixedPointArithmetic**: zero numerator division (both rounding modes), round-trip small, negative arithmetic, min/max with negatives

## Technical Decisions

- All new tests follow the established pattern: `#[allow(clippy::panic)]` on `mod tests`, `let-else` with `panic!()` instead of `.unwrap()`
- Hash consistency tests use `DefaultHasher` to verify equal values produce equal hashes
- No changes to library code — tests only

## Testing

- [x] Unit tests added (111 new tests across 20 files)
- [x] Manual testing performed (`cargo test --all-features` — 844 + 24 doc-tests)
- [x] `make lint-fix` passes
- [x] `make pre-push` passes

## Checklist

- [x] Code follows .internalDoc/09-RUST-GUIDELINES.md
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] Feature-gated code compiles with and without its feature
- [x] No `.unwrap()`, `.expect()`, or panics in library code

Closes #32