### PR TITLE
M9 #36: Promote all warn-level lints to deny for publish readiness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,19 +66,19 @@ serde_json = "1.0"
 
 [lints.rust]
 unsafe_code = "deny"
-missing_docs = "warn"
-missing_debug_implementations = "warn"
+missing_docs = "deny"
+missing_debug_implementations = "deny"
 
 [lints.clippy]
 unwrap_used = "deny"
 expect_used = "deny"
 panic = "deny"
-indexing_slicing = "warn"
-needless_collect = "warn"
-unnecessary_to_owned = "warn"
-clone_on_ref_ptr = "warn"
-missing_errors_doc = "warn"
-missing_panics_doc = "warn"
+indexing_slicing = "deny"
+needless_collect = "deny"
+unnecessary_to_owned = "deny"
+clone_on_ref_ptr = "deny"
+missing_errors_doc = "deny"
+missing_panics_doc = "deny"
 module_name_repetitions = "allow"
 similar_names = "allow"
 


### PR DESCRIPTION
## Summary

Hardens the lint configuration in `Cargo.toml` by promoting all `warn`-level lints to `deny`, ensuring zero-tolerance for quality issues. The entire codebase already passes all quality gates — this change locks that in so regressions are caught at compile time.

## Changes

- **`Cargo.toml`**: Promoted 8 lint levels from `warn` to `deny`

### Rust lints (`warn` → `deny`)
- `missing_docs` — all public items must have `///` doc comments
- `missing_debug_implementations` — all public types must impl `Debug`

### Clippy lints (`warn` → `deny`)
- `indexing_slicing` — prefer `.get()` over `[]` to avoid panics
- `needless_collect` — avoid unnecessary allocations
- `unnecessary_to_owned` — avoid redundant `.to_owned()`/`.to_string()`
- `clone_on_ref_ptr` — prefer explicit `Arc`/`Rc` cloning
- `missing_errors_doc` — all fallible functions document their errors
- `missing_panics_doc` — all panicking functions document when they panic

## Verification

All quality gates verified with zero warnings:

| Check | Status |
|-------|--------|
| `cargo fmt --all --check` | ✅ |
| `cargo clippy --all-targets --all-features -- -D warnings` | ✅ |
| `cargo clippy --all-targets --no-default-features -- -D warnings` | ✅ |
| `cargo test --all-features` (938 tests) | ✅ |
| `cargo doc --no-deps` (zero warnings) | ✅ |
| `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps` | ✅ |
| `cargo build --release --all-features` | ✅ |
| `make check` (includes `lint-no-std`) | ✅ |
| `make pre-push` | ✅ |
| `make doc-check` | ✅ |
| `make build-features` (all feature combos) | ✅ |
| No `unsafe` code (`deny`) | ✅ |
| No `.unwrap()`/`.expect()`/`panic` in lib code (`deny`) | ✅ |

## Technical Decisions

- Promoted lints to `deny` rather than leaving at `warn` because the codebase is publish-ready and regressions should be compile-time errors, not warnings that get ignored.
- The existing `allow` entries (`module_name_repetitions`, `similar_names`) are kept as-is since they are intentional style choices.

## Testing

- [x] Unit tests pass (885 tests)
- [x] Integration tests pass (29 tests)
- [x] Doc-tests pass (24 tests)
- [x] Manual testing performed (`cargo test --all-features`)

## Checklist

- [x] Code follows `.internalDoc/09-RUST-GUIDELINES.md`
- [x] All public items have `///` documentation
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] Feature-gated code compiles with and without its feature
- [x] No `.unwrap()`, `.expect()`, or panics in library code

Closes #36