### PR TITLE
M9 #39: Verify cargo package is clean and ready for crates.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ target/
 # Generated code (proto, SBE)
 src/api/grpc/generated/
 
+# Distribution artifacts
+dist/
+
 # Local development
 .local/
 /Docker/.erlang.cookie

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,15 @@ readme = "README.md"
 repository = "https://github.com/joaquinbejar/hydra-amm.git"
 keywords = ["amm", "defi", "liquidity", "swap", "market-maker"]
 categories = ["finance", "algorithms", "no-std"]
+exclude = [
+    ".dockerignore",
+    ".github/",
+    ".internalDoc/",
+    ".windsurf/",
+    "codecov.yml",
+    "Makefile",
+    "rust-toolchain.toml",
+]
 
 [lib]
 name = "hydra_amm"


### PR DESCRIPTION
## Summary

Cleans the crates.io package by excluding non-essential files and adds `dist/` to `.gitignore`. Verifies all publish-readiness criteria from Issue #39.

## Changes

### Cargo.toml — `[package].exclude` list
Excludes files that should not be shipped to crates.io consumers:
- `.dockerignore` — Docker build config, irrelevant to library users
- `.github/` — CI workflows, dependabot config
- `.internalDoc/` — internal specification documents
- `.windsurf/` — IDE issue tracking
- `codecov.yml` — coverage service config
- `Makefile` — developer convenience targets
- `rust-toolchain.toml` — pinned toolchain for CI

### .gitignore — add `dist/`
Added `dist/` exclusion as required by the acceptance criteria.

## Verification Results

| Check | Result |
|-------|--------|
| `cargo package --list` | 57 files (was 65), no `.internalDoc/`, no `.windsurf/`, no CI files |
| `cargo publish --dry-run` | ✅ succeeds at v0.1.1 |
| Package size | 714 KB (was 733 KB), 124 KB compressed |
| Cargo.toml metadata | Complete: name, version, edition, authors, description, license, readme, repository, keywords, categories |
| `.gitignore` | Excludes `target/`, `coverage/`, `dist/` |
| Dependencies | All have version constraints |
| Version | `0.1.1` (0.1.0 already published on crates.io) |

## Technical Decisions

- Version kept at `0.1.1` rather than resetting to `0.1.0` because `0.1.0` is already published on crates.io
- `Cargo.lock` is auto-included by cargo for reproducibility but is already in `.gitignore` (library crate convention)
- `tests/integration.rs` is included since it serves as a usage reference for consumers

## Testing

- [x] Manual testing performed (`cargo test --all-features`)
- [x] `cargo package --list --allow-dirty` verified
- [x] `cargo publish --dry-run --allow-dirty` verified
- [x] `make pre-push` passes (all 30 doc-tests, 885+ unit tests)

## Checklist

- [x] Code follows `.internalDoc/09-RUST-GUIDELINES.md`
- [x] All public items have `///` documentation
- [x] No warnings from `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check` passes
- [x] Feature-gated code compiles with and without its feature
- [x] No `.unwrap()`, `.expect()`, or panics in library code

Closes #39