### PR TITLE
fix(ci): skip cargo publish if already on crates.io and add codecov token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,5 +173,6 @@ jobs:
         if: hashFiles('lcov.info') != ''
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           fail_ci_if_error: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,20 @@ jobs:
       - name: Verify package
         run: cargo package --list
 
+      - name: Check if version already published
+        id: check
+        run: |
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          if cargo search hydra-amm --limit 1 | grep -q "hydra-amm = \"$VERSION\""; then
+            echo "already_published=true" >> $GITHUB_OUTPUT
+            echo "::notice::hydra-amm@$VERSION is already published on crates.io — skipping publish"
+          else
+            echo "already_published=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Publish to crates.io
+        if: steps.check.outputs.already_published == 'false'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
         run: cargo publish


### PR DESCRIPTION
## Summary

Fixes two CI issues:

1. **Release workflow fails** when `cargo publish` is run but the version is already on crates.io (e.g., manual publish before tag push)
2. **Codecov badge shows "unknown"** because `codecov-action@v5` requires a token for reliable uploads

## Changes

### Release workflow (`.github/workflows/release.yml`)
- Added a **version check step** before `cargo publish` that queries the crates.io index via `cargo search`
- If the version is already published, the publish step is **skipped** with a `::notice` annotation
- The `github-release` job still runs regardless (it depends on the publish job completing, not on whether publish was executed)

### CI workflow (`.github/workflows/ci.yml`)
- Added `token: ${{ secrets.CODECOV_TOKEN }}` to the `codecov-action@v5` upload step
- Required by codecov-action v5 for reliable coverage data uploads

## Action Required

For the codecov badge to work, you need to add the `CODECOV_TOKEN` secret to the repository:
1. Go to [codecov.io](https://app.codecov.io) → sign in with GitHub → select `hydra-amm`
2. Copy the upload token
3. Go to GitHub repo → Settings → Secrets → Actions → add `CODECOV_TOKEN`

## Testing

- [x] `make pre-push` passes
- [x] Workflow YAML is valid